### PR TITLE
ci: add Hugo build workflow for exampleSite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,20 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: peaceiris/actions-hugo@v3
+      - uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
           hugo-version: '0.146.0'
           extended: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.146.0'
+          extended: true
+
+      - name: Build exampleSite
+        working-directory: exampleSite
+        run: hugo --gc --minify

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stack Liquid Glass
 
+[![ci](https://github.com/rin2yh/hugo-theme-stack-liquid-glass/actions/workflows/ci.yml/badge.svg)](https://github.com/rin2yh/hugo-theme-stack-liquid-glass/actions/workflows/ci.yml)
+
 A glassmorphism-flavored Hugo theme — a liquid-glass redesign of [Hugo Theme Stack](https://github.com/CaiJimmy/hugo-theme-stack), with a near-zero JavaScript pipeline, light/dark mode, and built-in JSON search.
 
 > 日本語: Hugo Theme Stack をベースに、ガラス質感（glassmorphism）の UI とほぼ JS なしの配信パイプラインに作り変えたテーマです。ライト/ダーク切替、`/index.json` ベースの全文検索、TOC、Mermaid、外部 URL 投稿、日本語 i18n に対応しています。


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `hugo --gc --minify` against `exampleSite/` on every push to `main` and every pull request, so theme regressions surface automatically.
- Uses Hugo extended `0.146.0` (the minimum version called out in `README.md`) via `peaceiris/actions-hugo@v3`.
- Checks out submodules recursively so the theme symlink and any future submodules resolve.
- Adds a CI status badge to the top of `README.md`.

Closes #4.

## Test plan

- [x] First PR run of `ci` workflow turns green.
- [x] Badge in README renders against the new workflow.

## Follow-ups (not in this PR)

Tracked in the issue:
- Cache Hugo modules / resources between runs.
- Build against multiple Hugo versions to catch upgrade breakage.
- Lint Markdown / TOML.

---
_Generated by [Claude Code](https://claude.ai/code/session_013YtCfqKWFzENGvGzFuTAoJ)_