### PR TITLE
fix(article): pass SVG covers through unchanged (#9)

### DIFF
--- a/exampleSite/content/post/svg-cover/cover.svg
+++ b/exampleSite/content/post/svg-cover/cover.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7dd3fc"/>
+      <stop offset="1" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#g)"/>
+  <text x="60" y="340" font-family="sans-serif" font-size="72" fill="#0f172a">SVG cover</text>
+</svg>

--- a/exampleSite/content/post/svg-cover/index.md
+++ b/exampleSite/content/post/svg-cover/index.md
@@ -1,0 +1,10 @@
++++
+title = "SVG cover"
+date = 2026-04-26
+categories = ["Showcase"]
+tags = ["svg"]
+description = "Fixture confirming SVG cover artwork is served as-is without raster processing."
+image = "cover.svg"
++++
+
+This post pins down the SVG-cover code path: the cover image is passed through unchanged because Hugo's `.Resize` / `.Fill` are raster-only.

--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -15,8 +15,8 @@
   {{- if $image.exists }}
     <div class="article-card__cover">
       {{- if $image.resource -}}
-        {{- $thumb := $image.resource.Fill "640x360 q85" -}}
-        <img src="{{ $thumb.RelPermalink }}" width="{{ $thumb.Width }}" height="{{ $thumb.Height }}" loading="lazy" decoding="async" alt="{{ .Title }}">
+        {{- $thumb := partial "helper/image-thumb" (dict "Resource" $image.resource "Action" "Fill" "Spec" "640x360 q85") -}}
+        <img src="{{ $thumb.src }}"{{ with $thumb.width }} width="{{ . }}"{{ end }}{{ with $thumb.height }} height="{{ . }}"{{ end }} loading="lazy" decoding="async" alt="{{ .Title }}">
       {{- else -}}
         <img src="{{ $image.permalink }}" loading="lazy" decoding="async" alt="{{ .Title }}">
       {{- end -}}

--- a/layouts/partials/article/header.html
+++ b/layouts/partials/article/header.html
@@ -3,8 +3,8 @@
   {{- if $image.exists -}}
     <div class="article-cover">
       {{- if $image.resource -}}
-        {{- $thumb := $image.resource.Resize "1200x q85" -}}
-        <img src="{{ $thumb.RelPermalink }}" width="{{ $thumb.Width }}" height="{{ $thumb.Height }}" decoding="async" alt="{{ .Title }}">
+        {{- $thumb := partial "helper/image-thumb" (dict "Resource" $image.resource "Action" "Resize" "Spec" "1200x q85") -}}
+        <img src="{{ $thumb.src }}"{{ with $thumb.width }} width="{{ . }}"{{ end }}{{ with $thumb.height }} height="{{ . }}"{{ end }} decoding="async" alt="{{ .Title }}">
       {{- else -}}
         <img src="{{ $image.permalink }}" decoding="async" alt="{{ .Title }}">
       {{- end -}}

--- a/layouts/partials/helper/image-thumb.html
+++ b/layouts/partials/helper/image-thumb.html
@@ -1,0 +1,30 @@
+{{- /*
+  Image processing wrapper that passes SVG through unchanged.
+  Hugo's .Resize / .Fill / .Fit are raster-only and fail the build on SVG.
+
+  Input  dict: { Resource: Resource, Action: "Resize"|"Fill"|"Fit", Spec: string }
+  Output dict: { src: string, width: int, height: int }
+    - For SVG, width/height are 0 and src is the original RelPermalink.
+*/ -}}
+{{- $resource := .Resource -}}
+{{- $action := .Action | default "Resize" -}}
+{{- $spec := .Spec -}}
+{{- $src := $resource.RelPermalink -}}
+{{- $width := 0 -}}
+{{- $height := 0 -}}
+
+{{- if ne $resource.MediaType.SubType "svg" -}}
+  {{- $thumb := "" -}}
+  {{- if eq $action "Fill" -}}
+    {{- $thumb = $resource.Fill $spec -}}
+  {{- else if eq $action "Fit" -}}
+    {{- $thumb = $resource.Fit $spec -}}
+  {{- else -}}
+    {{- $thumb = $resource.Resize $spec -}}
+  {{- end -}}
+  {{- $src = $thumb.RelPermalink -}}
+  {{- $width = $thumb.Width -}}
+  {{- $height = $thumb.Height -}}
+{{- end -}}
+
+{{- return dict "src" $src "width" $width "height" $height -}}


### PR DESCRIPTION
Closes #9.

## Summary

- Add `layouts/partials/helper/image-thumb.html` — wraps `.Resize` / `.Fill` / `.Fit` and short-circuits on `MediaType.SubType == "svg"`, returning the original `RelPermalink` and zero dims so the `<img>` width/height attrs are omitted.
- Wire the helper into `layouts/partials/article/header.html` (the file the issue calls out) **and** `layouts/partials/article-card.html`, which has the identical raster-only call (`$image.resource.Fill "640x360 q85"`) and would crash the home/list page on the same Hugo 0.146 baseline.
- Add `exampleSite/content/post/svg-cover/` (post + `cover.svg`) so CI actively exercises the SVG-cover path that was previously dropped to keep 0.146 green (see `3f85c3b chore: drop SVG cover from showcase, restore 0.146 baseline`).

Out of scope and intentionally untouched: `widgets/profile.html` and `left-sidebar.html` use `.Fill` against a configured site avatar, not an article cover, and aren't part of issue #9.

## Test plan

- [x] CI builds `exampleSite` with the new `svg-cover` post on Hugo 0.146.0 (the documented minimum and the version pinned in `.github/workflows/ci.yml`). — verified by `build` job ✅ on commit `91fe019`.
- [x] Single-post page renders the SVG cover at full size (no width/height attrs, browser uses intrinsic). — guaranteed by template logic: helper returns `width: 0, height: 0` for SVG, and `{{ with $thumb.width }}` treats `0` as falsy so the attr is omitted.
- [x] Home / category / tag list pages render the SVG cover via `article-card.html` without crashing. — `hugo --gc --minify` would have failed during list rendering otherwise; it succeeded.
- [x] Existing raster covers (e.g. `glassmorphism-demo`) still produce a resized thumb with width/height attrs intact. — non-SVG branch preserves the original `.Resize` / `.Fill` call and emits `Width`/`Height`; CI build of the existing raster fixtures succeeded.