### PR TITLE
chore(theme): remove stale demosite URL

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,6 @@ license = "GPL-3.0-or-later"
 licenselink = "https://github.com/rin2yh/hugo-theme-stack-liquid-glass/blob/main/LICENSE"
 description = "Glassmorphism / Liquid Glass theme for Hugo. Derived from hugo-theme-stack with light/dark mode and a near-zero-JS pipeline."
 homepage = "https://github.com/rin2yh/hugo-theme-stack-liquid-glass"
-demosite = "https://rin2yh.github.io/blog/"
 tags = ["blog", "glassmorphism", "dark-mode", "minimal", "japanese", "responsive"]
 features = ["dark-mode", "search", "toc", "mermaid", "external-url", "related-posts", "i18n"]
 min_version = "0.146.0"


### PR DESCRIPTION
## Summary
- Drop the `demosite` field from `theme.toml`. It pointed at a personal blog rather than the exampleSite, so leaving it in is misleading.
- GitHub Pages will be reserved for theme usage docs; a dedicated exampleSite demo URL will be added later (e.g. when listing on themes.gohugo.io).

## Test plan
- [ ] Confirm `theme.toml` still parses (no `demosite` is fine — the field is optional).
- [ ] Verify no other file references the removed URL.


---
_Generated by [Claude Code](https://claude.ai/code/session_0162XQdKoTmcxHX2ReC2JxEG)_