### PR TITLE
fix(website): add missing search page to stop docs search 404

### DIFF
--- a/website/content/page/search/index.ja.md
+++ b/website/content/page/search/index.ja.md
@@ -1,0 +1,5 @@
+---
+title: "検索"
+layout: "search"
+description: "Stack Liquid Glass のドキュメントを検索します。"
+---

--- a/website/content/page/search/index.md
+++ b/website/content/page/search/index.md
@@ -1,0 +1,5 @@
+---
+title: "Search"
+layout: "search"
+description: "Search the Stack Liquid Glass documentation."
+---


### PR DESCRIPTION
## Summary

The docs site (`website/`) enables the homepage `search` widget but ships **no** `content/page/search/` page. The widget's form submits to `/page/search/` (or `/ja/page/search/` on the Japanese site), so submitting any search from the docs homepage produced a 404.

`exampleSite/` already includes this page — the docs site simply never got it. This PR mirrors the same minimal stub for the docs site, in both English and Japanese, so the form action resolves to a real page that loads `layouts/page/search.html` and the existing client-side search JS.

## Root cause

- `layouts/partials/widgets/search.html` resolves the form action via `site.GetPage "/page/search"`, falling back to a constructed `/page/search/` URL when no such page exists.
- In `website/`, the page does not exist in either language, so the form posts to a path with no content → 404.

## Changes

- `website/content/page/search/index.md` (en) — `layout: "search"`
- `website/content/page/search/index.ja.md` (ja) — `layout: "search"`

No theme/layout/JS changes; this is purely a missing-content fix in the docs site.

## Test plan

- [ ] `hugo --minify` in `website/` builds without errors (covered by `deploy-website.yml` matrix)
- [ ] Visit docs homepage `/`, type a query, submit → lands on `/page/search/` and renders results
- [ ] Visit `/ja/`, submit a query → lands on `/ja/page/search/` and renders results
- [ ] Direct navigation to `/page/search/` and `/ja/page/search/` returns 200, not 404

https://claude.ai/code/session_01AiASHRtg6pRXJ9RefpagGo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiASHRtg6pRXJ9RefpagGo)_