### PR TITLE
ci(release-please): use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -72,6 +72,6 @@ workflows — that would skip CI on the release PR. Setup steps:
    (Subscribe to no events; the App is only used as a token issuer.)
 2. Install the App on this repository.
 3. Add two repository secrets:
-   - `RELEASE_PLEASE_CLIENT_ID` — the App's Client ID (from the App's settings page).
+   - `RELEASE_PLEASE_APP_ID` — the App's Client ID (passed to the action's `client-id` input).
    - `RELEASE_PLEASE_PRIVATE_KEY` — the contents of the `.pem` private key.
 4. Push to `main`. The first run will open the initial release PR.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -72,6 +72,6 @@ workflows — that would skip CI on the release PR. Setup steps:
    (Subscribe to no events; the App is only used as a token issuer.)
 2. Install the App on this repository.
 3. Add two repository secrets:
-   - `RELEASE_PLEASE_APP_ID` — the App's numeric id.
+   - `RELEASE_PLEASE_CLIENT_ID` — the App's Client ID (from the App's settings page).
    - `RELEASE_PLEASE_PRIVATE_KEY` — the contents of the `.pem` private key.
 4. Push to `main`. The first run will open the initial release PR.


### PR DESCRIPTION
## Summary

The `app-id` input on [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) has been deprecated in favour of `client-id`. This PR switches the input key only — the existing `RELEASE_PLEASE_APP_ID` repository secret is kept as-is and re-wired into the new `client-id` input, so no maintainer setup change is required.

- `.github/workflows/release-please.yml`: `app-id:` → `client-id:` (still reads from `secrets.RELEASE_PLEASE_APP_ID`).
- `docs/releasing.md`: updated the secret description to clarify its value is the App's Client ID, passed to the action's `client-id` input.

## Test plan

- [ ] Merge to `main` and confirm the `release-please` workflow run succeeds (App token mints, release PR opens/updates as before).