### PR TITLE
chore(release-please): drop release-as now that v0.1.0 has shipped

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -61,14 +61,15 @@ in `release-please-config.json` for a one-off bump. See the
 [release-please docs](https://github.com/googleapis/release-please) for
 details.
 
-> **Note (first release).** While the manifest is bootstrapped at `0.0.0`,
-> release-please treats the next release as a "graduation" and proposes
+> **Historical note.** When the manifest was first bootstrapped at `0.0.0`,
+> release-please treated the next release as a "graduation" and proposed
 > `1.0.0`, even with `bump-minor-pre-major: true` (which only governs
-> breaking-change behaviour _within_ `0.x`). To pin the first release to
-> `0.1.0`, `release-as: "0.1.0"` is set on the package in
-> `release-please-config.json`. **Remove that field immediately after the
-> `v0.1.0` release PR is merged** — otherwise every subsequent release-please
-> PR will keep proposing `0.1.0` and the version will never advance.
+> breaking-change behaviour _within_ `0.x`). The first release was pinned
+> to `0.1.0` via a one-off `release-as: "0.1.0"` on the package, and that
+> override was removed once `v0.1.0` shipped. Future bootstraps of similar
+> projects can use the same workaround — and must remove `release-as`
+> immediately after the override release, or every subsequent release-please
+> PR will keep proposing the pinned version.
 
 ## Release automation setup (one-time)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,8 +16,7 @@
   ],
   "packages": {
     ".": {
-      "package-name": "hugo-theme-stack-liquid-glass",
-      "release-as": "0.1.0"
+      "package-name": "hugo-theme-stack-liquid-glass"
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #19. Now that `v0.1.0` has shipped, drop the one-off `release-as: "0.1.0"` override from `release-please-config.json` so the next release-please PR can bump normally (e.g. `0.1.0 → 0.2.0` for the next `feat:`, `0.1.0 → 0.1.1` for the next `fix:`).

If left in place, every subsequent release-please PR would keep proposing `0.1.0` and the version would never advance — exactly the failure mode the #19 PR description warned about.

## Changes

- `release-please-config.json`: remove `"release-as": "0.1.0"` from the `.` package.
- `docs/releasing.md`: rewrite the bootstrap note as a **historical** record so future maintainers still see the `0.0.0 → 1.0.0` quirk and the workaround that was used, without the language implying the override is currently active.

## Test plan

- [ ] After merge, the next push to `main` triggers `release-please` and either reuses or opens a release PR with a version **other than `0.1.0`** (e.g. `0.1.1` if only `fix:` commits, `0.2.0` if any `feat:` commits, or no PR if only no-bump types like `chore:`/`docs:` are pending).
- [ ] Manifest stays at `0.1.0` until that PR is merged.

https://claude.ai/code/session_01RYxww5yQ2aw4WYZxm8ydSb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYxww5yQ2aw4WYZxm8ydSb)_