### PR TITLE
fix(website): add missing archives page so docs archive widget links resolve

### DIFF
--- a/website/content/page/archives/index.ja.md
+++ b/website/content/page/archives/index.ja.md
@@ -1,0 +1,5 @@
+---
+title: "アーカイブ"
+layout: "archives"
+description: "Stack Liquid Glass のドキュメントページを年別に閲覧します。"
+---

--- a/website/content/page/archives/index.md
+++ b/website/content/page/archives/index.md
@@ -1,0 +1,5 @@
+---
+title: "Archives"
+layout: "archives"
+description: "Browse Stack Liquid Glass documentation pages by year."
+---


### PR DESCRIPTION
## Summary

- The docs site (`website/`) enables the homepage `archives` widget (`website/hugo.toml:34`), but no `content/page/archives/` page existed.
- The widget renders year links pointing at `/page/archives/#year-YYYY` (and `/ja/page/archives/#year-YYYY`), so clicking any year from the docs homepage returned **404**.
- Mirrors PR #16 (search page) by adding the page in both languages with `layout: "archives"`, so `layouts/page/archives.html` renders the docs grouped by year.

## Test plan

- [ ] `hugo --source website` builds without errors
- [ ] `/page/archives/` and `/ja/page/archives/` return 200 with year-grouped sections
- [ ] Year links from the homepage archive widget jump to `#year-YYYY` anchors on the archives page

https://claude.ai/code/session_017jVsjfFzA91HdEA6dm2Wtv

---
_Generated by [Claude Code](https://claude.ai/code/session_017jVsjfFzA91HdEA6dm2Wtv)_