### PR TITLE
fix(release-please): exclude website/ so docs-only changes don't bump theme version

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,13 @@ every commit on `main` must follow
 | `refactor:` | no version bump on its own          | Code Refactoring          |
 | `ci:`, `build:`, `chore:`, `test:`, `style:` | no version bump | hidden       |
 
+Commits that touch only `website/` (the Astro Starlight docs site) are
+ignored by release-please via `exclude-paths` in `release-please-config.json`.
+The docs site is shipped separately to GitHub Pages and is not part of the
+theme that consumers vendor, so its changes should not bump the theme version.
+A commit that touches both `website/` and theme files still counts as a
+theme-affecting commit.
+
 A breaking change is signalled by either a `!` after the type/scope or a
 `BREAKING CHANGE:` footer:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,12 +20,11 @@ every commit on `main` must follow
 | `refactor:` | no version bump on its own          | Code Refactoring          |
 | `ci:`, `build:`, `chore:`, `test:`, `style:` | no version bump | hidden       |
 
-Commits that touch only `website/` (the Astro Starlight docs site) are
-ignored by release-please via `exclude-paths` in `release-please-config.json`.
-The docs site is shipped separately to GitHub Pages and is not part of the
-theme that consumers vendor, so its changes should not bump the theme version.
-A commit that touches both `website/` and theme files still counts as a
-theme-affecting commit.
+`exclude-paths` in `release-please-config.json` skips commits that touch
+only `website/`, the Astro Starlight docs site shipped separately to
+GitHub Pages — not part of the theme that consumers vendor, so its
+changes should not bump the theme version. A commit that also touches
+theme files still counts as a theme-affecting commit.
 
 A breaking change is signalled by either a `!` after the type/scope or a
 `BREAKING CHANGE:` footer:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,8 @@
   ],
   "packages": {
     ".": {
-      "package-name": "hugo-theme-stack-liquid-glass"
+      "package-name": "hugo-theme-stack-liquid-glass",
+      "exclude-paths": ["website"]
     }
   }
 }


### PR DESCRIPTION
## Summary

`website/` is the Astro Starlight docs site that is published separately to GitHub Pages — it is not part of the Hugo theme that consumers vendor. But every `fix(website): …` / `feat(website): …` commit was triggering release-please to cut a theme release. `v0.1.1` was created entirely from `fix(website): add missing archives page…` commits with zero theme changes.

This adds `exclude-paths: ["website"]` to the `.` package in `release-please-config.json`. release-please's `exclude-paths` skips commits that touch **only** the listed paths; a commit that touches both `website/` and theme files still counts as theme-affecting, so docs-bundled-with-feature commits keep their normal effect.

Also documents the behaviour in `docs/releasing.md` so future contributors understand why a `fix(website): …` lands on `main` without producing a release PR update.

### Out of scope (intentionally minimal)

`docs/` (markdown contributing/releasing notes) and `images/` (README screenshots) have the same "not part of the shipped theme" property and could plausibly also be excluded. I left them in for now — happy to extend the list if you want, but the issue you raised was specifically about `website/`.

## Test plan

- [ ] After merge, push a `website/`-only change to `main` and confirm release-please does **not** open or update a release PR for it. _(pending — awaits a natural website-only commit.)_
- [x] Push a theme-touching change and confirm release-please still proposes a version bump. _(this PR's own `fix(release-please): …` merge is theme-touching; release PR #26 remains open with a version-bump proposal.)_
- [ ] Confirm a mixed commit (touches `website/` **and** `layouts/`) still triggers a release entry. _(pending — awaits a natural mixed commit.)_

## Post-merge verification

- ✅ Config landed on `main` — `release-please-config.json` now has `"exclude-paths": ["website"]` (commit 297efad).
- ✅ Semantics confirmed by inspection — release-please's [`commit-exclude.ts`](https://github.com/googleapis/release-please/blob/main/src/util/commit-exclude.ts) excludes a commit only when *every* file starts with `website/`. Spot-checked the entries currently in PR #26's changelog:
  - `feat(website): migrate docs site…` (962c2c6) also touches `.github/workflows/ci.yml`, `.github/workflows/deploy-website.yml`, `.gitignore` → correctly **not** excluded.
  - `refactor(website): split CI per workflow…` (af23e22) splits `.github/workflows/ci.yml` → correctly **not** excluded.
  - `fix(ci): …` (d0e4a63, 6df7b58) touch `.github/workflows/website.yml` → correctly **not** excluded.
  - `refactor(website): unify hero/LinkCard hrefs` (7a10431) only touches `website/package.json` + `website/src/content/docs/{,ja/}index.mdx` → **would** be filtered by the new config when release-please next regenerates.
- ⏳ The release PR's `CHANGELOG.md` hasn't been regenerated since this fix merged. The latest commit on the release branch (334bc6e8) is a `Merge branch 'main' into release-please-…` that only carried source files over — the changelog still reflects the pre-fix evaluation. The next release-please run on a push to `main` will refresh the changelog with `exclude-paths` applied, at which point items 1 and 3 become directly observable on PR #26.

I deliberately did not push test commits to `main` to actively verify items 1/3 — those would be visible/risky changes to a shared branch.

https://claude.ai/code/session_01RFXG5xN2zq8E7nmFptMCRz