### PR TITLE
docs(releasing): document non_fast_forward ruleset conflict with release-please

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -91,3 +91,27 @@ workflows — that would skip CI on the release PR. Setup steps:
    - `RELEASE_PLEASE_APP_ID` — the App's Client ID (passed to the action's `client-id` input).
    - `RELEASE_PLEASE_PRIVATE_KEY` — the contents of the `.pem` private key.
 4. Push to `main`. The first run will open the initial release PR.
+
+### Branch rulesets and force-push
+
+release-please rewrites the head commit of its release branch
+(`release-please--branches--main--components--…`) on every run — each new
+run regenerates `CHANGELOG.md` and `.release-please-manifest.json` against
+the current `main` and force-updates the branch to the new commit. This is
+a non-fast-forward update by design.
+
+A repository ruleset that includes a `non_fast_forward` rule covering this
+branch will block every release-please run after the initial one (the
+first run only creates the ref, which is allowed; subsequent runs need
+the force-update). Symptom: the workflow fails with
+
+```
+release-please failed: Error updating ref heads/release-please--branches--main--components--<package> to <sha>
+```
+
+If you want to keep `non_fast_forward` enforced for human-maintained
+branches, exclude release-please's own branch from the rule. In the
+ruleset's branch targeting, add an exclusion such as
+`refs/heads/release-please--*` (fnmatch). Alternatively, add the
+release-please GitHub App to the ruleset's `bypass_actors` so the bot can
+force-update while humans still cannot.


### PR DESCRIPTION
## Summary

While verifying the `exclude-paths` fix from #27, I noticed release PR #26's `CHANGELOG.md` had not been refreshed since my fix landed. Investigation via the Actions API showed runs #11–#13 of the `release-please` workflow all failed with:

```
release-please failed: Error updating ref heads/release-please--branches--main--components--hugo-theme-stack-liquid-glass to <sha>
```

Root cause: the repo's `all-branches` ruleset (id 15590819) applies `non_fast_forward` to `~ALL` branches with no bypass actors. release-please force-updates its own release branch on every run (it rewrites `chore(main): release …` against the current `main` each time) — so the first release-please run after the ruleset was added succeeded only because it _created_ the ref (creation counts as fast-forward); every subsequent run needed a force-update and was blocked.

This PR doesn't change any code or workflow. It only adds a "Branch rulesets and force-push" subsection to `docs/releasing.md` so the next person hitting the same wall can skip the investigation.

### What still needs to happen (outside this PR)

The actual unblocker is a repo settings change — pick one:

1. **Exclude `refs/heads/release-please--*` from the `all-branches` ruleset** (recommended; preserves the rule for human-maintained branches).
2. **Add the release-please GitHub App to the ruleset's `bypass_actors`** (bot can force-update; humans still can't).
3. Disable / scope down the `all-branches` ruleset.

I deliberately did **not** modify the ruleset via API — settings changes are outside the scope of "submit a PR" and you should pick which option fits your policy.

### Evidence

- Workflow runs (auth'd `/actions/workflows/release-please.yml/runs`):
  - #10 success (head `cf048991`, 14:52Z) — created the release branch ref.
  - #11 failure (head `0181f0bf`, 14:59Z), #12 failure (head `297efad9`, 15:00Z), #13 failure (head `57159fcd`, 15:22Z) — all hit "Error updating ref heads/release-please--branches--main--components--hugo-theme-stack-liquid-glass to …".
- Ruleset 15590819 (`all-branches`): `target: branch`, `include: ["~ALL"]`, `exclude: []`, rules: `[{ "type": "non_fast_forward" }]`, `bypass_actors: []`, `enforcement: active`, created 2026-04-27T07:37:17Z.
- Branch protection on the release branch itself: none (`Branch not protected`); the ruleset is the sole blocker.

## Test plan

- [x] Documentation only — no code paths to test.
- [ ] After applying one of the three settings options above, push any commit to `main` and confirm the next release-please run succeeds and refreshes `CHANGELOG.md` on PR #26.

https://claude.ai/code/session_01RFXG5xN2zq8E7nmFptMCRz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFXG5xN2zq8E7nmFptMCRz)_