### PR TITLE
fix(release-please): track theme paths only via include-paths allowlist

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,14 @@
   "packages": {
     ".": {
       "package-name": "hugo-theme-stack-liquid-glass",
-      "exclude-paths": ["website"]
+      "include-paths": [
+        "archetypes",
+        "assets",
+        "i18n",
+        "layouts",
+        "theme.toml",
+        "LICENSE"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- release-please の追跡対象を **denylist (`exclude-paths`)** から **allowlist (`include-paths`)** に切り替え。
- 対象は Hugo テーマ本体の構成物のみ: `archetypes/`, `assets/`, `i18n/`, `layouts/`, `theme.toml`, `LICENSE`。
- これで `.gitignore`, `.github/`, `docs/`, `exampleSite/`, `images/`, `README.md`, `website/` などテーマ本質ではないファイルの変更がバージョン bump やリリースノートに混入しなくなる。
- 将来新しい非テーマファイルが追加されても誤検知しない（許可リスト方式の利点）。

## Background

v0.1.1 のリリースノートには `fix(website): ...` の commit が含まれており、テーマコンシューマには無関係なドキュメントサイトの修正で patch リリースが発生していた。`exclude-paths: ["website"]` を後追いで追加していたが、`.gitignore` などの他のメタファイルには対応できていなかった。

## Test plan

- [ ] このブランチを main にマージした後、`.gitignore` のみを変更した commit を main に入れても release-please ワークフローがリリース PR を新規作成しない/changelog エントリが追加されないことを確認
- [ ] 逆に `layouts/` 配下を変更した commit では release-please がリリース PR を更新することを確認
- [ ] `release-please-config.json` の JSON 構文が valid（`python3 -m json.tool` で確認済み）

https://claude.ai/code/session_011zEqbAgZLuqFxq77Zm8SwR

---
_Generated by [Claude Code](https://claude.ai/code/session_011zEqbAgZLuqFxq77Zm8SwR)_