### PR TITLE
ci(release-please): unblock releases and document snooze-label recovery

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,9 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Allows re-running release-please by hand (e.g. after clearing a stale
+  # snoozed release PR) without pushing a throwaway commit to main.
+  workflow_dispatch:
 
 permissions: {}
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -77,6 +77,44 @@ details.
 > immediately after the override release, or every subsequent release-please
 > PR will keep proposing the pinned version.
 
+## Troubleshooting
+
+### `state cannot be changed. There is already an open pull request…`
+
+If a release-please run fails at the end with a log like:
+
+```
+✔ Successfully opened pull request: <new-PR>.
+⚠ updated code for <new-PR>, but update requested for <old-PR>
+##[error]release-please failed: Validation Failed: …"state cannot be changed.
+There is already an open pull request from
+release-please--branches--main--… to main."
+```
+
+the run actually created a valid release PR (`<new-PR>`) but then tried to
+reconcile an **older release PR that was closed without merging** and still
+carries release-please's tracking labels (`autorelease: pending`,
+`autorelease: snooze`). release-please treats such a PR as "snoozed" and
+attempts to reopen it on the shared release branch, which GitHub rejects
+because the new PR already occupies that branch — failing the whole job.
+
+The commit-parsing warnings earlier in the log
+(`❯ commit could not be parsed: … Merge pull request …`) are harmless:
+release-please always skips non–Conventional-Commit merge commits.
+
+**Recovery:**
+
+1. Find the stale closed (not merged) release PR — it will be titled
+   `chore(main): release …` and still show the `autorelease: pending` /
+   `autorelease: snooze` labels.
+2. Remove those labels from it.
+3. Re-run the workflow (Actions → **release-please** → **Run workflow**, or
+   push any commit to `main`). It will now update the existing open release
+   PR without the conflict.
+
+The freshly created release PR from the failed run is valid — merge it as
+usual to cut the release.
+
 ## Release automation setup (one-time)
 
 The workflow runs as a GitHub App rather than with the default `GITHUB_TOKEN`,


### PR DESCRIPTION
## Why release-please failed

The last `release-please` run on `main` (run `28563186507`) exited non-zero with:

```
✔ Successfully opened pull request: 51.
⚠ updated code for 51, but update requested for 31
##[error]release-please failed: Validation Failed: …"state cannot be changed.
There is already an open pull request from
release-please--branches--main--… to main."
```

- The many `❯ commit could not be parsed: … Merge pull request …` lines are **harmless** — release-please always skips non–Conventional-Commit merge commits.
- The real failure: **PR #31**, a release PR from April that was **closed without merging**, still carried the labels `autorelease: pending` and `autorelease: snooze`. release-please treats such a PR as "snoozed" and tried to reopen it on the shared release branch. Because the run had just created the current release PR (**#51**) on that same branch, GitHub rejected the state change and the job failed.

The 0.3.0 release PR (**#51**) was itself created correctly — the job only failed on the follow-up reconciliation of the stale PR.

## Fix

1. **Operational (already applied):** cleared the stale `autorelease: pending` / `autorelease: snooze` labels from the closed PR #31, so release-please no longer tries to reconcile it. This unblocks releases immediately — merging #51 cuts 0.3.0.
2. **This PR (durable):**
   - Add `workflow_dispatch` to `.github/workflows/release-please.yml` so the workflow can be re-run by hand (e.g. after clearing a stale snoozed PR) without pushing a throwaway commit to `main`.
   - Document the failure signature and the label-cleanup recovery in `docs/releasing.md`.

## Notes

- No theme code changes; touches only CI config and docs.
- `workflow_dispatch` becomes usable once this merges to `main` (manual dispatch reads the workflow from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bjSVXbH2K7aY6q38uzaYB)_