### PR TITLE
feat(mobile): floating TOC + share buttons for small screens

### DIFF
--- a/assets/css/partials/_components-mobile-actions.css
+++ b/assets/css/partials/_components-mobile-actions.css
@@ -1,9 +1,10 @@
-/* Mobile floating actions — TOC + share reachable at any scroll position.
-   Visible only on small screens; the desktop sidebar handles wide layouts. */
+/* Mobile floating actions — a speed-dial FAB (TOC + share) reachable at any
+   scroll position. Visible only on small screens; the desktop sidebar handles
+   wide layouts. */
 .mobile-actions {
   display: none;
 }
-.mobile-toc[hidden] {
+.mobile-toc {
   display: none;
 }
 
@@ -14,46 +15,112 @@
     display: none;
   }
 
-  /* Floating action buttons */
+  /* Speed-dial container: actions stack above the main FAB, right-aligned */
   .mobile-actions {
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
     gap: var(--space-sm);
     position: fixed;
     right: max(var(--space-md), env(safe-area-inset-right));
     bottom: max(var(--space-lg), env(safe-area-inset-bottom));
     z-index: var(--z-overlay);
   }
+
+  /* Round glass buttons — shared base for the main FAB and the action icons */
+  .mobile-actions__fab,
   .mobile-actions__btn {
-    width: 52px;
-    height: 52px;
     border-radius: var(--radius-full);
     display: inline-flex;
     align-items: center;
     justify-content: center;
     color: var(--color-text);
-    cursor: pointer;
     box-shadow: var(--shadow-float);
+  }
+  .mobile-actions__fab {
+    width: 56px;
+    height: 56px;
+    cursor: pointer;
     transition: transform var(--dur-fast) var(--ease-glass),
       background var(--dur-fast);
   }
+  .mobile-actions__btn {
+    width: 48px;
+    height: 48px;
+  }
+  .mobile-actions__fab svg,
   .mobile-actions__btn svg {
     position: relative;
     z-index: 2;
     width: 22px;
     height: 22px;
   }
-  .mobile-actions__btn:active {
+  .mobile-actions__fab:active {
     transform: scale(0.92);
   }
+  /* The "+" trigger rotates into an "×" while the menu is open */
+  .mobile-actions__fab svg {
+    transition: transform var(--dur-mid) var(--ease-glass);
+  }
+  .mobile-actions--menu.is-open .mobile-actions__fab svg {
+    transform: rotate(135deg);
+  }
 
-  /* TOC bottom sheet */
+  /* Fan-out actions (label + icon), hidden until the FAB is tapped */
+  .mobile-actions__menu {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: var(--space-sm);
+  }
+  .mobile-actions__action {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(8px) scale(0.9);
+    pointer-events: none;
+    transition: opacity var(--dur-fast) var(--ease-smooth),
+      transform var(--dur-fast) var(--ease-glass);
+  }
+  .mobile-actions.is-open .mobile-actions__action {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+  .mobile-actions.is-open .mobile-actions__action:nth-child(2) {
+    transition-delay: 45ms;
+  }
+  .mobile-actions__label {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    line-height: 1;
+    white-space: nowrap;
+    padding: 7px 12px;
+    border-radius: var(--radius-full);
+    color: var(--color-text);
+    background: var(--glass-white-md);
+    border: 1px solid var(--glass-border-subtle);
+    box-shadow: var(--shadow-glass);
+  }
+
+  /* TOC bottom sheet — visibility driven purely by the .is-open class */
   .mobile-toc {
+    display: flex;
     position: fixed;
     inset: 0;
     z-index: var(--z-modal);
-    display: flex;
     align-items: flex-end;
+    visibility: hidden;
+    transition: visibility 0s linear var(--dur-mid);
+  }
+  .mobile-toc.is-open {
+    visibility: visible;
+    transition-delay: 0s;
   }
   .mobile-toc__overlay {
     position: absolute;
@@ -63,6 +130,9 @@
     -webkit-backdrop-filter: blur(4px);
     opacity: 0;
     transition: opacity var(--dur-mid) var(--ease-smooth);
+  }
+  .mobile-toc.is-open .mobile-toc__overlay {
+    opacity: 1;
   }
   .mobile-toc__sheet {
     position: relative;
@@ -76,9 +146,6 @@
       max(var(--space-lg), env(safe-area-inset-bottom));
     transform: translateY(100%);
     transition: transform var(--dur-mid) var(--ease-glass);
-  }
-  .mobile-toc.is-open .mobile-toc__overlay {
-    opacity: 1;
   }
   .mobile-toc.is-open .mobile-toc__sheet {
     transform: translateY(0);
@@ -138,7 +205,9 @@
   }
 }
 
+[data-theme="light"] .mobile-actions__fab,
 [data-theme="light"] .mobile-actions__btn,
+[data-theme="light"] .mobile-actions__label,
 [data-theme="light"] .mobile-toc__sheet {
   background: rgba(255, 255, 255, 0.85);
   border-color: rgba(15, 23, 42, 0.1);

--- a/assets/css/partials/_components-mobile-actions.css
+++ b/assets/css/partials/_components-mobile-actions.css
@@ -27,7 +27,10 @@
     z-index: var(--z-overlay);
   }
 
-  /* Round glass buttons — shared base for the main FAB and the action icons */
+  /* Round buttons — shared base for the main FAB and the action icons.
+     Deliberately NOT .glass: these are fixed and always on screen, so a
+     backdrop blur would repaint every scroll frame; a near-opaque surface
+     keeps the icons legible over any content for far less cost. */
   .mobile-actions__fab,
   .mobile-actions__btn {
     border-radius: var(--radius-full);
@@ -35,9 +38,7 @@
     align-items: center;
     justify-content: center;
     color: var(--color-text);
-    /* More opaque than plain .glass so the icons stay legible over any
-       article content (code blocks, images) while scrolling */
-    background: rgba(18, 24, 44, 0.72);
+    background: var(--glass-opaque);
     border: 1px solid var(--glass-border-bright);
     box-shadow: var(--shadow-float);
   }
@@ -66,7 +67,7 @@
   .mobile-actions__fab svg {
     transition: transform var(--dur-mid) var(--ease-glass);
   }
-  .mobile-actions--menu.is-open .mobile-actions__fab svg {
+  .mobile-actions.is-open .mobile-actions__fab svg {
     transform: rotate(135deg);
   }
 
@@ -107,7 +108,7 @@
     padding: 7px 12px;
     border-radius: var(--radius-full);
     color: var(--color-text);
-    background: rgba(18, 24, 44, 0.78);
+    background: var(--glass-opaque);
     border: 1px solid var(--glass-border-bright);
     box-shadow: var(--shadow-float);
   }
@@ -163,19 +164,10 @@
     justify-content: space-between;
     margin-bottom: var(--space-sm);
   }
-  .mobile-toc__title {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-display);
-    font-size: var(--text-md);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    opacity: 0.8;
-  }
-  .mobile-toc__title svg {
-    width: 14px;
-    height: 14px;
+  /* Reuse the sidebar TOC title styling; only drop its bottom margin so it
+     centers against the close button in the flex header. */
+  .mobile-toc__header .toc__title {
+    margin-bottom: 0;
   }
   .mobile-toc__close {
     display: inline-flex;
@@ -209,13 +201,9 @@
   }
 }
 
-[data-theme="light"] .mobile-actions__fab,
-[data-theme="light"] .mobile-actions__btn,
-[data-theme="light"] .mobile-actions__label,
+/* The FAB / action / label surfaces theme themselves via --glass-opaque;
+   only the .glass-based sheet needs a light-theme background bump. */
 [data-theme="light"] .mobile-toc__sheet {
   background: rgba(255, 255, 255, 0.85);
   border-color: rgba(15, 23, 42, 0.1);
-}
-[data-theme="light"] .mobile-toc__title {
-  opacity: 1;
 }

--- a/assets/css/partials/_components-mobile-actions.css
+++ b/assets/css/partials/_components-mobile-actions.css
@@ -1,0 +1,148 @@
+/* Mobile floating actions — TOC + share reachable at any scroll position.
+   Visible only on small screens; the desktop sidebar handles wide layouts. */
+.mobile-actions {
+  display: none;
+}
+.mobile-toc[hidden] {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  /* The sidebar copies live at the bottom of the page — the FAB replaces them */
+  .layout-grid__sidebar .toc,
+  .layout-grid__sidebar .twitter-share {
+    display: none;
+  }
+
+  /* Floating action buttons */
+  .mobile-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    position: fixed;
+    right: max(var(--space-md), env(safe-area-inset-right));
+    bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+    z-index: var(--z-overlay);
+  }
+  .mobile-actions__btn {
+    width: 52px;
+    height: 52px;
+    border-radius: var(--radius-full);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text);
+    cursor: pointer;
+    box-shadow: var(--shadow-float);
+    transition: transform var(--dur-fast) var(--ease-glass),
+      background var(--dur-fast);
+  }
+  .mobile-actions__btn svg {
+    position: relative;
+    z-index: 2;
+    width: 22px;
+    height: 22px;
+  }
+  .mobile-actions__btn:active {
+    transform: scale(0.92);
+  }
+
+  /* TOC bottom sheet */
+  .mobile-toc {
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-modal);
+    display: flex;
+    align-items: flex-end;
+  }
+  .mobile-toc__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    opacity: 0;
+    transition: opacity var(--dur-mid) var(--ease-smooth);
+  }
+  .mobile-toc__sheet {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-height: 70vh;
+    border-radius: var(--radius-2xl) var(--radius-2xl) 0 0;
+    padding: var(--space-md) var(--space-lg)
+      max(var(--space-lg), env(safe-area-inset-bottom));
+    transform: translateY(100%);
+    transition: transform var(--dur-mid) var(--ease-glass);
+  }
+  .mobile-toc.is-open .mobile-toc__overlay {
+    opacity: 1;
+  }
+  .mobile-toc.is-open .mobile-toc__sheet {
+    transform: translateY(0);
+  }
+
+  .mobile-toc__header {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-sm);
+  }
+  .mobile-toc__title {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    opacity: 0.8;
+  }
+  .mobile-toc__title svg {
+    width: 14px;
+    height: 14px;
+  }
+  .mobile-toc__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--radius-full);
+    color: var(--color-text);
+    cursor: pointer;
+    transition: background var(--dur-fast);
+  }
+  .mobile-toc__close:hover {
+    background: var(--glass-white);
+  }
+  .mobile-toc__close svg {
+    width: 18px;
+    height: 18px;
+  }
+  .mobile-toc__inner {
+    position: relative;
+    z-index: 2;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  body.sheet-open {
+    overflow: hidden;
+  }
+}
+
+[data-theme="light"] .mobile-actions__btn,
+[data-theme="light"] .mobile-toc__sheet {
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(15, 23, 42, 0.1);
+}
+[data-theme="light"] .mobile-toc__title {
+  opacity: 1;
+}

--- a/assets/css/partials/_components-mobile-actions.css
+++ b/assets/css/partials/_components-mobile-actions.css
@@ -35,6 +35,10 @@
     align-items: center;
     justify-content: center;
     color: var(--color-text);
+    /* More opaque than plain .glass so the icons stay legible over any
+       article content (code blocks, images) while scrolling */
+    background: rgba(18, 24, 44, 0.72);
+    border: 1px solid var(--glass-border-bright);
     box-shadow: var(--shadow-float);
   }
   .mobile-actions__fab {
@@ -103,9 +107,9 @@
     padding: 7px 12px;
     border-radius: var(--radius-full);
     color: var(--color-text);
-    background: var(--glass-white-md);
-    border: 1px solid var(--glass-border-subtle);
-    box-shadow: var(--shadow-glass);
+    background: rgba(18, 24, 44, 0.78);
+    border: 1px solid var(--glass-border-bright);
+    box-shadow: var(--shadow-float);
   }
 
   /* TOC bottom sheet — visibility driven purely by the .is-open class */

--- a/assets/css/partials/_tokens.css
+++ b/assets/css/partials/_tokens.css
@@ -10,6 +10,10 @@
   --glass-border-subtle: rgba(255, 255, 255, 0.12);
   --glass-border-bright: rgba(255, 255, 255, 0.5);
 
+  /* Near-opaque surface for controls that must stay legible over any content
+     (no backdrop blur needed) */
+  --glass-opaque: rgba(18, 24, 44, 0.78);
+
   --blur-sm: blur(8px);
   --blur-md: blur(18px);
   --blur-lg: blur(32px);
@@ -105,6 +109,8 @@
   --glass-border: rgba(15, 23, 42, 0.14);
   --glass-border-subtle: rgba(15, 23, 42, 0.09);
   --glass-border-bright: rgba(15, 23, 42, 0.22);
+
+  --glass-opaque: rgba(255, 255, 255, 0.9);
 
   --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.1),
     inset 0 1px 0 rgba(255, 255, 255, 0.9);

--- a/assets/icons/hash.svg
+++ b/assets/icons/hash.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="9" x2="20" y2="9"/><line x1="4" y1="15" x2="20" y2="15"/><line x1="10" y1="3" x2="8" y2="21"/><line x1="16" y1="3" x2="14" y2="21"/></svg>

--- a/assets/icons/plus.svg
+++ b/assets/icons/plus.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>

--- a/assets/icons/share.svg
+++ b/assets/icons/share.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>

--- a/assets/icons/x.svg
+++ b/assets/icons/x.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>

--- a/assets/js/mobile-actions.js
+++ b/assets/js/mobile-actions.js
@@ -1,7 +1,7 @@
 /**
- * mobile-actions.js — floating TOC + share buttons for small screens.
- *   Share uses the Web Share API when available, falling back to an X/Twitter
- *   intent URL. The TOC opens as a bottom sheet.
+ * mobile-actions.js — speed-dial FAB (TOC + share) for small screens.
+ *   Tapping the FAB fans out the actions. Share uses the Web Share API when
+ *   available, falling back to an X/Twitter intent URL. TOC opens as a sheet.
  */
 (function () {
   "use strict";
@@ -10,75 +10,82 @@
     var root = document.querySelector(".mobile-actions");
     if (!root) return;
 
-    // --- Share ---
-    var shareBtn = root.querySelector("[data-mobile-share]");
-    if (shareBtn) {
-      shareBtn.addEventListener("click", function () {
-        var title = root.getAttribute("data-share-title") || document.title;
-        var url = root.getAttribute("data-share-url") || window.location.href;
-        var fallback = root.getAttribute("data-share-fallback");
-        if (navigator.share) {
-          navigator.share({ title: title, url: url }).catch(function () {});
-        } else if (fallback) {
-          window.open(fallback, "_blank", "noopener,noreferrer");
+    // --- Share (either the solo FAB or the speed-dial action) ---
+    function doShare() {
+      var title = root.getAttribute("data-share-title") || document.title;
+      var url = root.getAttribute("data-share-url") || window.location.href;
+      var fallback = root.getAttribute("data-share-fallback");
+      if (navigator.share) {
+        navigator.share({ title: title, url: url }).catch(function () {});
+      } else if (fallback) {
+        window.open(fallback, "_blank", "noopener,noreferrer");
+      }
+    }
+
+    // --- Speed-dial menu ---
+    var fabToggle = root.querySelector("[data-mobile-actions-toggle]");
+    function closeMenu() {
+      root.classList.remove("is-open");
+      if (fabToggle) fabToggle.setAttribute("aria-expanded", "false");
+    }
+    if (fabToggle) {
+      fabToggle.addEventListener("click", function (e) {
+        e.stopPropagation();
+        var open = root.classList.toggle("is-open");
+        fabToggle.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+      document.addEventListener("click", function (e) {
+        if (root.classList.contains("is-open") && !root.contains(e.target)) {
+          closeMenu();
         }
       });
     }
 
+    Array.prototype.forEach.call(
+      root.querySelectorAll("[data-mobile-share]"),
+      function (btn) {
+        btn.addEventListener("click", function () {
+          closeMenu();
+          doShare();
+        });
+      }
+    );
+
     // --- TOC bottom sheet ---
     var sheet = document.getElementById("mobile-toc-sheet");
-    var toggle = root.querySelector("[data-mobile-toc-toggle]");
-    if (!sheet || !toggle) return;
+    var tocToggle = root.querySelector("[data-mobile-toc-toggle]");
+    if (!sheet || !tocToggle) return;
 
-    var closeTimer = null;
-
-    function open() {
-      if (closeTimer) {
-        clearTimeout(closeTimer);
-        closeTimer = null;
-      }
-      sheet.hidden = false;
-      // Force reflow so the slide-up transition runs from the hidden state.
-      void sheet.offsetWidth;
+    function openSheet() {
+      closeMenu();
       sheet.classList.add("is-open");
-      toggle.setAttribute("aria-expanded", "true");
+      tocToggle.setAttribute("aria-expanded", "true");
       document.body.classList.add("sheet-open");
-      document.addEventListener("keydown", onKey);
     }
-
-    function close() {
+    function closeSheet() {
       sheet.classList.remove("is-open");
-      toggle.setAttribute("aria-expanded", "false");
+      tocToggle.setAttribute("aria-expanded", "false");
       document.body.classList.remove("sheet-open");
-      document.removeEventListener("keydown", onKey);
-      closeTimer = setTimeout(function () {
-        sheet.hidden = true;
-      }, 400);
     }
 
-    function onKey(e) {
-      if (e.key === "Escape") close();
-    }
+    tocToggle.addEventListener("click", openSheet);
 
-    toggle.addEventListener("click", function () {
-      if (sheet.hidden) open();
-      else close();
+    // One delegated handler: close on the overlay/close button or a TOC link.
+    sheet.addEventListener("click", function (e) {
+      if (
+        e.target.closest("[data-mobile-toc-close]") ||
+        e.target.closest('.mobile-toc__inner a[href^="#"]')
+      ) {
+        closeSheet();
+      }
     });
 
-    Array.prototype.forEach.call(
-      sheet.querySelectorAll("[data-mobile-toc-close]"),
-      function (el) {
-        el.addEventListener("click", close);
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        closeMenu();
+        closeSheet();
       }
-    );
-
-    // Dismiss the sheet once the reader jumps to a section.
-    Array.prototype.forEach.call(
-      sheet.querySelectorAll('.mobile-toc__inner a[href^="#"]'),
-      function (a) {
-        a.addEventListener("click", close);
-      }
-    );
+    });
   }
 
   if (document.readyState === "loading") {

--- a/assets/js/mobile-actions.js
+++ b/assets/js/mobile-actions.js
@@ -1,0 +1,89 @@
+/**
+ * mobile-actions.js — floating TOC + share buttons for small screens.
+ *   Share uses the Web Share API when available, falling back to an X/Twitter
+ *   intent URL. The TOC opens as a bottom sheet.
+ */
+(function () {
+  "use strict";
+
+  function init() {
+    var root = document.querySelector(".mobile-actions");
+    if (!root) return;
+
+    // --- Share ---
+    var shareBtn = root.querySelector("[data-mobile-share]");
+    if (shareBtn) {
+      shareBtn.addEventListener("click", function () {
+        var title = root.getAttribute("data-share-title") || document.title;
+        var url = root.getAttribute("data-share-url") || window.location.href;
+        var fallback = root.getAttribute("data-share-fallback");
+        if (navigator.share) {
+          navigator.share({ title: title, url: url }).catch(function () {});
+        } else if (fallback) {
+          window.open(fallback, "_blank", "noopener,noreferrer");
+        }
+      });
+    }
+
+    // --- TOC bottom sheet ---
+    var sheet = document.getElementById("mobile-toc-sheet");
+    var toggle = root.querySelector("[data-mobile-toc-toggle]");
+    if (!sheet || !toggle) return;
+
+    var closeTimer = null;
+
+    function open() {
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+        closeTimer = null;
+      }
+      sheet.hidden = false;
+      // Force reflow so the slide-up transition runs from the hidden state.
+      void sheet.offsetWidth;
+      sheet.classList.add("is-open");
+      toggle.setAttribute("aria-expanded", "true");
+      document.body.classList.add("sheet-open");
+      document.addEventListener("keydown", onKey);
+    }
+
+    function close() {
+      sheet.classList.remove("is-open");
+      toggle.setAttribute("aria-expanded", "false");
+      document.body.classList.remove("sheet-open");
+      document.removeEventListener("keydown", onKey);
+      closeTimer = setTimeout(function () {
+        sheet.hidden = true;
+      }, 400);
+    }
+
+    function onKey(e) {
+      if (e.key === "Escape") close();
+    }
+
+    toggle.addEventListener("click", function () {
+      if (sheet.hidden) open();
+      else close();
+    });
+
+    Array.prototype.forEach.call(
+      sheet.querySelectorAll("[data-mobile-toc-close]"),
+      function (el) {
+        el.addEventListener("click", close);
+      }
+    );
+
+    // Dismiss the sheet once the reader jumps to a section.
+    Array.prototype.forEach.call(
+      sheet.querySelectorAll('.mobile-toc__inner a[href^="#"]'),
+      function (a) {
+        a.addEventListener("click", close);
+      }
+    );
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -99,6 +99,9 @@ other = "Next"
 [toggleMenu]
 other = "Toggle menu"
 
+[close]
+other = "Close"
+
 [copyCode]
 other = "Copy code"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -99,6 +99,9 @@ other = "次へ"
 [toggleMenu]
 other = "メニューを開閉"
 
+[close]
+other = "閉じる"
+
 [copyCode]
 other = "コードをコピー"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,6 +21,8 @@
       </div>
     </div>
 
+    {{ partial "mobile-actions.html" . }}
+
     {{- /* Mermaid lazy loader */ -}}
     {{- partial "mermaid.html" . -}}
     {{ if .Store.Get "hasMermaid" }}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -39,6 +39,7 @@
   "css/partials/_components-toc.css"
   "css/partials/_components-pagination.css"
   "css/partials/_components-sidebar.css"
+  "css/partials/_components-mobile-actions.css"
   "css/partials/_components-progress.css"
   "css/partials/_scene-blob.css"
   "css/partials/_animations.css"
@@ -67,6 +68,7 @@
 {{- $jsFiles := slice
   "js/liquid-glass.js"
   "js/toc.js"
+  "js/mobile-actions.js"
   "js/copy-code.js"
   "js/progress.js"
 -}}

--- a/layouts/partials/helper/share-url.html
+++ b/layouts/partials/helper/share-url.html
@@ -1,0 +1,6 @@
+{{- /*
+  Build the X/Twitter share-intent URL for a page.
+  Usage: {{ partial "helper/share-url" . }} where . is a Page.
+*/ -}}
+{{- $text := printf "%s\n%s" .Title .Permalink | urlquery -}}
+{{- printf "https://twitter.com/intent/tweet?text=%s" $text -}}

--- a/layouts/partials/mobile-actions.html
+++ b/layouts/partials/mobile-actions.html
@@ -1,4 +1,4 @@
-{{- /* Mobile floating actions — TOC bottom sheet + share.
+{{- /* Mobile floating actions — speed-dial FAB (TOC + share).
   Rendered on single pages only; hidden on desktop via CSS. */ -}}
 {{- if .IsPage -}}
   {{- $title := .Title -}}
@@ -6,24 +6,35 @@
   {{- $text := printf "%s\n%s" $title $url | urlquery -}}
   {{- $fallback := printf "https://twitter.com/intent/tweet?text=%s" $text -}}
   {{- $hasToc := and .Fragments (gt (len .Fragments.Headings) 0) -}}
-  <div class="mobile-actions" data-share-title="{{ $title }}" data-share-url="{{ $url }}" data-share-fallback="{{ $fallback }}">
+  <div class="mobile-actions{{ if $hasToc }} mobile-actions--menu{{ end }}" data-share-title="{{ $title }}" data-share-url="{{ $url }}" data-share-fallback="{{ $fallback }}">
     {{- if $hasToc -}}
-      <button type="button" class="mobile-actions__btn glass" data-mobile-toc-toggle aria-label="{{ T "tableOfContents" }}" aria-expanded="false" aria-controls="mobile-toc-sheet">
-        {{ partial "helper/icon" "list" }}
+      <div class="mobile-actions__menu" role="menu">
+        <button type="button" class="mobile-actions__action" role="menuitem" data-mobile-toc-toggle aria-controls="mobile-toc-sheet" aria-expanded="false">
+          <span class="mobile-actions__label">{{ T "tableOfContents" }}</span>
+          <span class="mobile-actions__btn glass">{{ partial "helper/icon" "hash" }}</span>
+        </button>
+        <button type="button" class="mobile-actions__action" role="menuitem" data-mobile-share>
+          <span class="mobile-actions__label">{{ T "shareTo" }}</span>
+          <span class="mobile-actions__btn glass">{{ partial "helper/icon" "share" }}</span>
+        </button>
+      </div>
+      <button type="button" class="mobile-actions__fab glass" data-mobile-actions-toggle aria-expanded="false" aria-label="{{ T "toggleMenu" }}">
+        {{ partial "helper/icon" "plus" }}
+      </button>
+    {{- else -}}
+      <button type="button" class="mobile-actions__fab glass" data-mobile-share aria-label="{{ T "shareTo" }}">
+        {{ partial "helper/icon" "share" }}
       </button>
     {{- end -}}
-    <button type="button" class="mobile-actions__btn glass" data-mobile-share aria-label="{{ T "shareTo" }}">
-      {{ partial "helper/icon" "share" }}
-    </button>
   </div>
 
   {{- if $hasToc -}}
-    <div class="mobile-toc" id="mobile-toc-sheet" hidden>
+    <div class="mobile-toc" id="mobile-toc-sheet">
       <div class="mobile-toc__overlay" data-mobile-toc-close></div>
       <div class="mobile-toc__sheet glass" role="dialog" aria-modal="true" aria-label="{{ T "tableOfContents" }}">
         <div class="mobile-toc__header">
           <span class="mobile-toc__title">
-            {{ partial "helper/icon" "list" }}
+            {{ partial "helper/icon" "hash" }}
             {{ T "tableOfContents" }}
           </span>
           <button type="button" class="mobile-toc__close" data-mobile-toc-close aria-label="{{ T "close" }}">

--- a/layouts/partials/mobile-actions.html
+++ b/layouts/partials/mobile-actions.html
@@ -1,0 +1,37 @@
+{{- /* Mobile floating actions — TOC bottom sheet + share.
+  Rendered on single pages only; hidden on desktop via CSS. */ -}}
+{{- if .IsPage -}}
+  {{- $title := .Title -}}
+  {{- $url := .Permalink -}}
+  {{- $text := printf "%s\n%s" $title $url | urlquery -}}
+  {{- $fallback := printf "https://twitter.com/intent/tweet?text=%s" $text -}}
+  {{- $hasToc := and .Fragments (gt (len .Fragments.Headings) 0) -}}
+  <div class="mobile-actions" data-share-title="{{ $title }}" data-share-url="{{ $url }}" data-share-fallback="{{ $fallback }}">
+    {{- if $hasToc -}}
+      <button type="button" class="mobile-actions__btn glass" data-mobile-toc-toggle aria-label="{{ T "tableOfContents" }}" aria-expanded="false" aria-controls="mobile-toc-sheet">
+        {{ partial "helper/icon" "list" }}
+      </button>
+    {{- end -}}
+    <button type="button" class="mobile-actions__btn glass" data-mobile-share aria-label="{{ T "shareTo" }}">
+      {{ partial "helper/icon" "share" }}
+    </button>
+  </div>
+
+  {{- if $hasToc -}}
+    <div class="mobile-toc" id="mobile-toc-sheet" hidden>
+      <div class="mobile-toc__overlay" data-mobile-toc-close></div>
+      <div class="mobile-toc__sheet glass" role="dialog" aria-modal="true" aria-label="{{ T "tableOfContents" }}">
+        <div class="mobile-toc__header">
+          <span class="mobile-toc__title">
+            {{ partial "helper/icon" "list" }}
+            {{ T "tableOfContents" }}
+          </span>
+          <button type="button" class="mobile-toc__close" data-mobile-toc-close aria-label="{{ T "close" }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </div>
+        <div class="mobile-toc__inner toc__inner">{{ .TableOfContents }}</div>
+      </div>
+    </div>
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/mobile-actions.html
+++ b/layouts/partials/mobile-actions.html
@@ -3,26 +3,25 @@
 {{- if .IsPage -}}
   {{- $title := .Title -}}
   {{- $url := .Permalink -}}
-  {{- $text := printf "%s\n%s" $title $url | urlquery -}}
-  {{- $fallback := printf "https://twitter.com/intent/tweet?text=%s" $text -}}
-  {{- $hasToc := and .Fragments (gt (len .Fragments.Headings) 0) -}}
-  <div class="mobile-actions{{ if $hasToc }} mobile-actions--menu{{ end }}" data-share-title="{{ $title }}" data-share-url="{{ $url }}" data-share-fallback="{{ $fallback }}">
+  {{- $fallback := partial "helper/share-url" . -}}
+  {{- $hasToc := gt (len .Fragments.Headings) 0 -}}
+  <div class="mobile-actions" data-share-title="{{ $title }}" data-share-url="{{ $url }}" data-share-fallback="{{ $fallback }}">
     {{- if $hasToc -}}
       <div class="mobile-actions__menu" role="menu">
         <button type="button" class="mobile-actions__action" role="menuitem" data-mobile-toc-toggle aria-controls="mobile-toc-sheet" aria-expanded="false">
           <span class="mobile-actions__label">{{ T "tableOfContents" }}</span>
-          <span class="mobile-actions__btn glass">{{ partial "helper/icon" "hash" }}</span>
+          <span class="mobile-actions__btn">{{ partial "helper/icon" "hash" }}</span>
         </button>
         <button type="button" class="mobile-actions__action" role="menuitem" data-mobile-share>
           <span class="mobile-actions__label">{{ T "shareTo" }}</span>
-          <span class="mobile-actions__btn glass">{{ partial "helper/icon" "share" }}</span>
+          <span class="mobile-actions__btn">{{ partial "helper/icon" "share" }}</span>
         </button>
       </div>
-      <button type="button" class="mobile-actions__fab glass" data-mobile-actions-toggle aria-expanded="false" aria-label="{{ T "toggleMenu" }}">
+      <button type="button" class="mobile-actions__fab" data-mobile-actions-toggle aria-expanded="false" aria-label="{{ T "toggleMenu" }}">
         {{ partial "helper/icon" "plus" }}
       </button>
     {{- else -}}
-      <button type="button" class="mobile-actions__fab glass" data-mobile-share aria-label="{{ T "shareTo" }}">
+      <button type="button" class="mobile-actions__fab" data-mobile-share aria-label="{{ T "shareTo" }}">
         {{ partial "helper/icon" "share" }}
       </button>
     {{- end -}}
@@ -33,12 +32,12 @@
       <div class="mobile-toc__overlay" data-mobile-toc-close></div>
       <div class="mobile-toc__sheet glass" role="dialog" aria-modal="true" aria-label="{{ T "tableOfContents" }}">
         <div class="mobile-toc__header">
-          <span class="mobile-toc__title">
+          <span class="toc__title">
             {{ partial "helper/icon" "hash" }}
             {{ T "tableOfContents" }}
           </span>
           <button type="button" class="mobile-toc__close" data-mobile-toc-close aria-label="{{ T "close" }}">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            {{ partial "helper/icon" "x" }}
           </button>
         </div>
         <div class="mobile-toc__inner toc__inner">{{ .TableOfContents }}</div>

--- a/layouts/partials/widgets/twitter-share.html
+++ b/layouts/partials/widgets/twitter-share.html
@@ -1,9 +1,6 @@
 {{- $page := .page -}}
 {{- if $page.IsPage -}}
-  {{- $title := $page.Title -}}
-  {{- $url := $page.Permalink -}}
-  {{- $text := printf "%s\n%s" $title $url | urlquery -}}
-  {{- $twitterUrl := printf "https://twitter.com/intent/tweet?text=%s" $text -}}
+  {{- $twitterUrl := partial "helper/share-url" $page -}}
   <aside class="widget twitter-share">
     <span class="twitter-share__title">{{ T "shareTo" }}</span>
     {{- $icon := partial "helper/icon" "brand-twitter" -}}


### PR DESCRIPTION
## 背景 / 課題

スマホ表示（≤1024px）では `layout-grid` が1カラムになり、サイドバーの**目次**と**共有**ウィジェットが `order: 2` で記事本文の一番下へ回されます。そのため長い記事だと、目次や共有ボタンにたどり着くのに記事全体をスクロールし切る必要があり、操作が「遠い」状態でした。

## 変更内容

スクロール位置に関係なく常に届く**フローティングアクションボタン**を追加しました。

- **目次ボタン** — タップするとガラス調のボトムシートで目次を表示（見出しのあるページのみ）
- **共有ボタン** — `navigator.share`（Web Share API）でOS標準の共有シートを開き、非対応環境では従来どおりX（Twitter）のインテントURLにフォールバック
- モバイルではサイドバー内の目次・共有の重複表示を非表示化
- ボタンは単一ページ（`.IsPage`）のみに描画

## 追加・変更ファイル

- `layouts/partials/mobile-actions.html` — FAB とボトムシートのマークアップ（新規）
- `assets/css/partials/_components-mobile-actions.css` — FAB / ボトムシートのスタイル（新規、モバイル限定）
- `assets/js/mobile-actions.js` — 共有処理とボトムシートの開閉（新規）
- `assets/icons/share.svg` — 共有アイコン（新規）
- `layouts/_default/baseof.html` — パーシャルの読み込み
- `layouts/partials/head/head.html` — CSS/JS をバンドルへ追加
- `i18n/{en,ja}.toml` — `close`（閉じる）ラベルを追加

## 動作確認

- `hugo v0.150.0` で exampleSite をビルド（成功）。生成HTMLで以下を確認:
  - 記事ページ: 目次ボタン・共有ボタン・ボトムシートが出力される
  - 見出しなしページ（About）: 共有ボタンのみ、目次ボタン/シートは非出力
  - CSS/JS がバンドルに含まれる

## 備考

- ライト/ダーク両テーマ対応、`env(safe-area-inset-*)` でノッチ端末に配慮、`Escape` キー・オーバーレイタップ・目次リンクタップでシートを閉じます。
- デスクトップ表示は従来のサイドバーのまま（FABはCSSで非表示）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXny51nY5sRy8uRbZU5vop

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXny51nY5sRy8uRbZU5vop)_