### PR TITLE
fix(toc): keep mobile TOC close button legible in dark theme

### DIFF
--- a/assets/css/partials/_components-mobile-actions.css
+++ b/assets/css/partials/_components-mobile-actions.css
@@ -175,6 +175,10 @@
   .mobile-toc__header .toc__title {
     margin-bottom: 0;
   }
+  /* Match the FAB/action surface: a near-opaque circle stays legible in either
+     theme (dark disc + white icon in dark mode, light disc + dark icon in
+     light mode). A transparent base let a light hover fill wash out the white
+     "×" against the sheet in dark mode. */
   .mobile-toc__close {
     display: inline-flex;
     align-items: center;
@@ -183,11 +187,13 @@
     height: 36px;
     border-radius: var(--radius-full);
     color: var(--color-text);
+    background: var(--glass-opaque);
+    border: 1px solid var(--glass-border-bright);
     cursor: pointer;
-    transition: background var(--dur-fast);
+    transition: border-color var(--dur-fast);
   }
   .mobile-toc__close:hover {
-    background: var(--glass-white);
+    border-color: var(--color-text);
   }
   .mobile-toc__close svg {
     width: 18px;


### PR DESCRIPTION
## What

The mobile Table of Contents close (×) button was hard to see in dark theme (see reported screenshot). It used a transparent base surface with a light translucent hover/tap fill (`--glass-white`), so the white × icon washed out against the light fill on the glass sheet.

## Change

`.mobile-toc__close` now uses the same near-opaque circular surface as the FAB / action buttons (`--glass-opaque` background + `--glass-border-bright` border). Because these tokens are theme-aware, the button renders as:

- **Dark theme:** dark disc + white × → clearly legible
- **Light theme:** light disc + dark × → clearly legible

Hover now brightens the border (`--color-text`) instead of filling the background, so the icon never washes out in any state.

## Files
- `assets/css/partials/_components-mobile-actions.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7KfXTdB9KQXQdssgXraMx)_