### PR TITLE
docs: add Conventional Commits rules in CLAUDE.md

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,12 +1,8 @@
-# CLAUDE.md
-
-Guidance for Claude Code (and contributors) working in this repository.
-
-## Commit messages: Conventional Commits
+# Commit messages: Conventional Commits
 
 All commits **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Releases and the `CHANGELOG.md` are generated automatically by [release-please](https://github.com/googleapis/release-please) from these commit messages, so the format is not optional — non-conforming commits are silently dropped from the changelog and version bumps.
 
-### Format
+## Format
 
 ```
 <type>(<scope>): <description>
@@ -20,7 +16,7 @@ All commits **must** follow the [Conventional Commits](https://www.conventionalc
 - Keep the description short; lowercase, no trailing period.
 - `scope` is optional but encouraged (e.g. `share`, `mobile`, `ogp`, `sidebar`, `search`, `docs`).
 
-### Allowed types
+## Allowed types
 
 These match the `changelog-sections` in `release-please-config.json`:
 
@@ -38,7 +34,7 @@ These match the `changelog-sections` in `release-please-config.json`:
 | `test`     | Tests                    | Hidden from changelog                  |
 | `style`    | Styles                   | Hidden from changelog (formatting)     |
 
-### Breaking changes
+## Breaking changes
 
 Signal a breaking change with a `!` after the type/scope, and/or a `BREAKING CHANGE:` footer. This triggers a major version bump (or a minor bump while the theme is pre-1.0, per `bump-minor-pre-major`).
 
@@ -48,7 +44,7 @@ feat(share)!: drop the legacy share-url param
 BREAKING CHANGE: the `shareUrl` param has been removed; use `params.shareIcon` instead.
 ```
 
-### Examples
+## Examples
 
 ```
 feat(mobile): add floating TOC + share buttons for small screens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and contributors) working in this repository.
+
+## Commit messages: Conventional Commits
+
+All commits **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Releases and the `CHANGELOG.md` are generated automatically by [release-please](https://github.com/googleapis/release-please) from these commit messages, so the format is not optional — non-conforming commits are silently dropped from the changelog and version bumps.
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- Use the imperative mood in the description (e.g. "add", not "added" / "adds").
+- Keep the description short; lowercase, no trailing period.
+- `scope` is optional but encouraged (e.g. `share`, `mobile`, `ogp`, `sidebar`, `search`, `docs`).
+
+### Allowed types
+
+These match the `changelog-sections` in `release-please-config.json`:
+
+| Type       | Changelog section        | Notes                                  |
+| ---------- | ------------------------ | -------------------------------------- |
+| `feat`     | Features                 | Triggers a minor version bump          |
+| `fix`      | Bug Fixes                | Triggers a patch version bump          |
+| `perf`     | Performance Improvements |                                        |
+| `revert`   | Reverts                  |                                        |
+| `docs`     | Documentation            |                                        |
+| `refactor` | Code Refactoring         |                                        |
+| `ci`       | Continuous Integration   | Hidden from changelog                  |
+| `build`    | Build System             | Hidden from changelog                  |
+| `chore`    | Miscellaneous Chores     | Hidden from changelog                  |
+| `test`     | Tests                    | Hidden from changelog                  |
+| `style`    | Styles                   | Hidden from changelog (formatting)     |
+
+### Breaking changes
+
+Signal a breaking change with a `!` after the type/scope, and/or a `BREAKING CHANGE:` footer. This triggers a major version bump (or a minor bump while the theme is pre-1.0, per `bump-minor-pre-major`).
+
+```
+feat(share)!: drop the legacy share-url param
+
+BREAKING CHANGE: the `shareUrl` param has been removed; use `params.shareIcon` instead.
+```
+
+### Examples
+
+```
+feat(mobile): add floating TOC + share buttons for small screens
+fix(sidebar): stop sticky TOC from overlapping stacked widgets
+docs(ogp): document link cards on the docs site instead of the README
+refactor(mobile): dedup share URL, reuse TOC title, drop wasteful blur
+chore: bump dependencies
+```


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` documenting the **Conventional Commits** rules for this repository so contributors (and Claude Code) write commit messages that release-please can consume.

The repo already relies on [release-please](https://github.com/googleapis/release-please) to generate `CHANGELOG.md` and version bumps from commit messages, but the required format was undocumented. This makes the rules explicit and keeps them in sync with the existing `release-please-config.json`.

## Details

- Documents the required `type(scope): description` format and imperative-mood convention.
- Lists the allowed commit types in a table mirroring the `changelog-sections` in `release-please-config.json` (`feat`, `fix`, `perf`, `revert`, `docs`, `refactor`, `ci`, `build`, `chore`, `test`, `style`), including which are hidden from the changelog.
- Explains breaking-change signaling (`!` / `BREAKING CHANGE:`) and how it interacts with `bump-minor-pre-major` while the theme is pre-1.0.
- Includes real examples drawn from the project's own history.

## Notes

Documentation only — no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ2FwgPrdarqeKTf2UV1DY)_