### PR TITLE
refactor(share): unblock release-please and cut the owed 0.4.0

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -105,9 +105,6 @@ other = "Close"
 [copyCode]
 other = "Copy code"
 
-[shareOnTwitter]
-other = "Share"
-
 [copyLink]
 other = "Copy link"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -105,9 +105,6 @@ other = "閉じる"
 [copyCode]
 other = "コードをコピー"
 
-[shareOnTwitter]
-other = "共有"
-
 [copyLink]
 other = "リンクをコピー"
 

--- a/layouts/partials/mobile-actions.html
+++ b/layouts/partials/mobile-actions.html
@@ -14,8 +14,8 @@
           <span class="mobile-actions__btn">{{ partial "helper/icon" "hash" }}</span>
         </button>
       {{- end -}}
-      <a href="{{ $twitterUrl }}" target="_blank" rel="noopener noreferrer" class="mobile-actions__action" role="menuitem" data-mobile-action aria-label="{{ T "shareOnTwitter" }}">
-        <span class="mobile-actions__label">{{ T "shareOnTwitter" }}</span>
+      <a href="{{ $twitterUrl }}" target="_blank" rel="noopener noreferrer" class="mobile-actions__action" role="menuitem" data-mobile-action aria-label="{{ T "shareTo" }}">
+        <span class="mobile-actions__label">{{ T "shareTo" }}</span>
         <span class="mobile-actions__btn">{{ partial "helper/share-icon" . }}</span>
       </a>
       <button type="button" class="mobile-actions__action" role="menuitem" data-mobile-action

--- a/layouts/partials/widgets/twitter-share.html
+++ b/layouts/partials/widgets/twitter-share.html
@@ -4,7 +4,7 @@
   <aside class="widget twitter-share">
     <span class="twitter-share__title">{{ T "shareTo" }}</span>
     <div class="twitter-share__actions">
-      <a href="{{ $twitterUrl }}" target="_blank" rel="noopener noreferrer" class="twitter-share__btn" aria-label="{{ T "shareOnTwitter" }}">
+      <a href="{{ $twitterUrl }}" target="_blank" rel="noopener noreferrer" class="twitter-share__btn" aria-label="{{ T "shareTo" }}">
         {{ partial "helper/share-icon" . }}
       </a>
       <button type="button" class="twitter-share__btn twitter-share__btn--link"


### PR DESCRIPTION
## なぜ release-please が反応していなかったか

0.3.0 リリース(コミット `8ae24d6`)以降に main へマージされた PR #57 のコミットが、すべて非 Conventional な件名でした:

```
Genericize the share label (drop X from user-facing text)
Make the share icon site-configurable via params.shareIcon
Rebrand share action to X with a proper brand logo
Mobile float: show X share and copy-link explicitly
...
```

release-please はコミット件名の `feat:` / `fix:` などのプレフィックスから版数と CHANGELOG を導出します。前回リリース以降に releasable な type のコミットが 1 件も無かったため、リリース PR が生成されない状態でした。

マージ済みの main 履歴は書き換えできない(公開履歴の破壊)ため、**新しい Conventional なコミットを 1 本足して release-please を再始動させる**のが正攻法です。

## この PR の変更

`release-please-config.json` に `include-paths` が設定されており、対象パスに触れないコミット(=完全な空コミット)はパスフィルタで無視される恐れがあります。そこで、トリガーを **included パス内の実質的な修正**にしました。

- **`refactor(share)`**: #57 の「シェアラベル汎用化」の取りこぼしを修正。i18n キー `[shareOnTwitter]` は値が `[shareTo]`(`"Share"` / `"共有"`)と重複し、Twitter 名のまま残っていました。デスクトップウィジェットとモバイル FAB の `aria-label` / ラベル参照を汎用の `shareTo` に統一し、重複した Twitter 名キーを削除。
- コミットに **`Release-As: 0.4.0`** フッタを付与し、#57 で出荷済みの機能(`params.shareIcon` 設定化・モバイル共有 FAB)に対して本来支払われるべきだったマイナーバンプ(0.3.0 → 0.4.0)を強制。

## 変更ファイル

- `i18n/en.toml`, `i18n/ja.toml` — Twitter 名の重複キー `shareOnTwitter` を削除
- `layouts/partials/widgets/twitter-share.html`, `layouts/partials/mobile-actions.html` — 参照を `shareTo` に統一

## マージ後の想定フロー

1. main へマージ → `release-please.yml` が起動
2. release-please が `Release-As: 0.4.0` を尊重し、`chore(main): release 0.4.0` のリリース PR を生成
3. 自動生成される CHANGELOG は今回の refactor のみで薄いため、**#57 で出荷済みの機能(共有アイコン設定化・モバイル共有 FAB)の記載はリリース PR 上で手動追記**してからマージ

> Conventional Commits の強制ルール(commit lint 等)の追加は別 PR で対応中。この PR は止まっているリリースの復旧のみを扱います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3YQKBujvpESSyRyW1GvbT)_