### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,37 @@
+name: pr-title-lint
+
+# Squash-merge uses the PR title as the commit subject, and release-please
+# parses those commits — so the title must follow Conventional Commits or the
+# release automation silently skips the change. This gate enforces that.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Match the types release-please recognises (see release-please-config.json).
+          types: |
+            feat
+            fix
+            perf
+            revert
+            docs
+            refactor
+            ci
+            build
+            chore
+            test
+            style


### PR DESCRIPTION
## What

Adds a lightweight CI check that fails a PR when its **title** doesn't follow Conventional Commits.

## Why

The repo squash-merges PRs, so the PR title becomes the commit subject that release-please parses. A non-conventional title (e.g. `Fix TOC close button…`) is silently ignored by release-please and no release is proposed — exactly the situation hit on #59. This gate catches it at PR time.

## How

- New workflow `.github/workflows/pr-title-lint.yml` using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request), SHA-pinned (v5.5.3) to match the repo's action-pinning convention.
- Runs on `pull_request_target` (`opened`/`edited`/`synchronize`/`reopened`); only needs `pull-requests: read` and does not check out PR code.
- Allowed `types` mirror the commit types in `release-please-config.json` (`feat`, `fix`, `perf`, `revert`, `docs`, `refactor`, `ci`, `build`, `chore`, `test`, `style`).

## Notes

- Pairs best with repo settings **Squash-merge only** + **"Default to PR title for squash merge commits"**, so the validated title is what lands on `main`.
- This is CI tooling only — no theme/runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7KfXTdB9KQXQdssgXraMx)_