### PR TITLE
ci(security): use pull_request instead of pull_request_target for title lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -3,8 +3,14 @@ name: pr-title-lint
 # Squash-merge uses the PR title as the commit subject, and release-please
 # parses those commits — so the title must follow Conventional Commits or the
 # release automation silently skips the change. This gate enforces that.
+#
+# Use `pull_request` (not `pull_request_target`): this job only reads the PR
+# title from the event payload and never checks out PR code, so it does not
+# need the base-repo context and secrets that `pull_request_target` grants to
+# code from forks — running that against untrusted PRs is a known privilege-
+# escalation footgun.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## What

Switches the `pr-title-lint` workflow trigger from `pull_request_target` to `pull_request`.

## Why

`pull_request_target` runs in the context of the **base** repository with access to its secrets and a read/write `GITHUB_TOKEN` — even when the PR comes from a fork. That is a well-known privilege-escalation footgun: if such a workflow ever checks out or executes PR-controlled code, untrusted contributors can exfiltrate secrets or push to the repo.

This job doesn't need any of that. It only reads the PR title from the event payload (`amannn/action-semantic-pull-request`) and never checks out PR code, so the safe `pull_request` trigger is strictly sufficient:

- The PR title is present in the `pull_request` event payload just as it is in `pull_request_target`.
- The job only requires `pull-requests: read`, which the `pull_request` token provides.
- Fork PRs get a read-only token under `pull_request`, eliminating the secret/token exposure.

## Changes

- `.github/workflows/pr-title-lint.yml`: `on.pull_request_target` → `on.pull_request` (same `types`), plus a comment documenting why the safe trigger is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPAGYiPsyzh863S89rZAEA)_