### PR TITLE
feat(fonts)!: ship no webfonts by default, own them from the site side

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -33,12 +33,15 @@ rssFullContent = true
 # shareIcon = "your-icon"
 description = "Demo site for the Stack Liquid Glass Hugo theme."
 [params.fonts]
-# Webfonts loaded from Google Fonts. Both default to true.
-#   googleFonts      — master toggle. false skips the request and uses the
-#                      system-font fallbacks (fastest, most private).
-#   japaneseBodyFont — include Noto Sans JP, the heavy CJK webfont that
-#                      dominates the Google Fonts payload. Non-Japanese
-#                      sites can set false to drop it.
+# By default the theme loads NO webfonts (system fonts → fastest, best
+# PageSpeed). Bring your own from the site side: inject them in
+# layouts/partials/head/custom.html and point the variables below at them:
+#   display = "'Playfair Display', serif"
+#   ui      = "'Inter', system-ui, sans-serif"
+#   body    = "'Inter', 'Noto Sans JP', sans-serif"
+#   mono    = "'Fira Code', monospace"
+# This demo just flips on the theme's original bundled typography so the
+# showcase looks as designed. japaneseBodyFont = false drops Noto Sans JP.
 googleFonts = true
 japaneseBodyFont = true
 [params.ogp]

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -32,6 +32,15 @@ rssFullContent = true
 # external-link icon. The theme ships no brand-logo asset (trademarks).
 # shareIcon = "your-icon"
 description = "Demo site for the Stack Liquid Glass Hugo theme."
+[params.fonts]
+# Webfonts loaded from Google Fonts. Both default to true.
+#   googleFonts      — master toggle. false skips the request and uses the
+#                      system-font fallbacks (fastest, most private).
+#   japaneseBodyFont — include Noto Sans JP, the heavy CJK webfont that
+#                      dominates the Google Fonts payload. Non-Japanese
+#                      sites can set false to drop it.
+googleFonts = true
+japaneseBodyFont = true
 [params.ogp]
 # Draw the site name in the bottom-left of generated OGP images. `true` uses
 # the site title; a string draws a custom label. Unset = brand-neutral image.

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -32,18 +32,13 @@ rssFullContent = true
 # external-link icon. The theme ships no brand-logo asset (trademarks).
 # shareIcon = "your-icon"
 description = "Demo site for the Stack Liquid Glass Hugo theme."
-[params.fonts]
-# By default the theme loads NO webfonts (system fonts → fastest, best
-# PageSpeed). Bring your own from the site side: inject them in
-# layouts/partials/head/custom.html and point the variables below at them:
+# Fonts: the theme ships no webfonts. This demo loads its typography from the
+# site side in layouts/partials/head/custom.html — the pattern any site uses to
+# bring its own fonts. To restyle without touching CSS, override the font
+# variables here, e.g.:
+#   [params.fonts]
 #   display = "'Playfair Display', serif"
-#   ui      = "'Inter', system-ui, sans-serif"
 #   body    = "'Inter', 'Noto Sans JP', sans-serif"
-#   mono    = "'Fira Code', monospace"
-# This demo just flips on the theme's original bundled typography so the
-# showcase looks as designed. japaneseBodyFont = false drops Noto Sans JP.
-googleFonts = true
-japaneseBodyFont = true
 [params.ogp]
 # Draw the site name in the bottom-left of generated OGP images. `true` uses
 # the site title; a string draws a custom label. Unset = brand-neutral image.

--- a/exampleSite/layouts/partials/head/custom.html
+++ b/exampleSite/layouts/partials/head/custom.html
@@ -1,0 +1,10 @@
+{{- /* Site-side font loading — this is the pattern every site uses to bring
+       its own fonts (the theme itself ships no webfonts). It loads the theme's
+       original typography; the CSS variables (--font-display etc.) already name
+       these families first, so no [params.fonts] overrides are needed.
+       Loaded async (media=print → onload) so it never blocks first paint. */ -}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+{{- $href := "https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap" -}}
+<link rel="stylesheet" href="{{ $href }}" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="{{ $href }}"></noscript>

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -16,21 +16,27 @@
 <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
 <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
 
-{{- /* Fonts — load asynchronously to avoid blocking first paint.
-       Configurable via [params.fonts]:
-         googleFonts      (default true)  master toggle. false → skip the
-                          request entirely and use the system-font fallbacks
-                          baked into the CSS variables (best PageSpeed / privacy).
-         japaneseBodyFont (default true)  include the heavy Noto Sans JP CJK
-                          webfont. Non-Japanese sites can set false to drop the
-                          bulk of the Google Fonts CSS payload. */ -}}
-{{- $useGoogleFonts := true -}}
+{{- /* Fonts.
+       The theme ships NO webfonts by default — the CSS variables fall back to
+       system fonts, which is the fastest, most private option and keeps tools
+       like PageSpeed from flagging a big unused-CSS Google Fonts stylesheet.
+       Bring your own fonts entirely from the site side:
+         1. Inject the <link>/<style>/preload for your fonts via
+            layouts/partials/head/custom.html (rendered near the end of <head>).
+         2. Point the CSS variables at them with [params.fonts] —
+            display / ui / body / mono (see the block after the stylesheet).
+       Or, to restore the theme's original bundled typography with no other
+       setup, flip [params.fonts] googleFonts = true. */ -}}
+{{- $useGoogleFonts := false -}}
 {{- $useJPFont := true -}}
 {{- with .Site.Params.fonts -}}
   {{- if isset . "googlefonts" -}}{{- $useGoogleFonts = .googleFonts -}}{{- end -}}
   {{- if isset . "japanesebodyfont" -}}{{- $useJPFont = .japaneseBodyFont -}}{{- end -}}
 {{- end -}}
 {{- if $useGoogleFonts -}}
+  {{- /* Opt-in: the theme's original Google Fonts set, loaded asynchronously.
+         japaneseBodyFont (default true) drops the heavy Noto Sans JP CJK font
+         for non-Japanese sites. */ -}}
   {{- $families := slice "family=Italiana" "family=DM+Sans:wght@400;500" "family=JetBrains+Mono:wght@400;600" -}}
   {{- if $useJPFont -}}
     {{- $families = $families | append "family=Noto+Sans+JP:wght@400;500;700" -}}
@@ -84,6 +90,24 @@
   {{- end }}
 {{- end }}
 
+{{- /* Font-family overrides — point the CSS variables at your own fonts without
+       editing CSS. Emitted after the stylesheet so it wins by source order.
+         [params.fonts]
+         display = "'Playfair Display', serif"   # headings / brand
+         ui      = "'Inter', system-ui, sans-serif"
+         body    = "'Inter', 'Noto Sans JP', sans-serif"
+         mono    = "'Fira Code', monospace" */ -}}
+{{- with .Site.Params.fonts -}}
+  {{- $overrides := slice -}}
+  {{- with .display -}}{{- $overrides = $overrides | append (printf "--font-display:%s;" .) -}}{{- end -}}
+  {{- with .ui -}}{{- $overrides = $overrides | append (printf "--font-ui:%s;" .) -}}{{- end -}}
+  {{- with .body -}}{{- $overrides = $overrides | append (printf "--font-body:%s;" .) -}}{{- end -}}
+  {{- with .mono -}}{{- $overrides = $overrides | append (printf "--font-mono:%s;" .) -}}{{- end -}}
+  {{- with $overrides -}}
+    <style>{{ printf ":root{%s}" (delimit . "") | safeCSS }}</style>
+  {{- end -}}
+{{- end -}}
+
 {{- /* JS bundle */ -}}
 {{- $jsFiles := slice
   "js/liquid-glass.js"
@@ -110,3 +134,7 @@
 
 {{- /* Optional analytics */ -}}
 {{ if hugo.IsProduction }}{{ partial "google-analytics.html" . }}{{ end }}
+
+{{- /* Site-provided <head> extras (webfonts, preloads, verification meta…).
+       Create layouts/partials/head/custom.html in your own site to use it. */ -}}
+{{- if templates.Exists "partials/head/custom.html" -}}{{ partial "head/custom.html" . }}{{- end -}}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -30,8 +30,8 @@
 {{- $useGoogleFonts := false -}}
 {{- $useJPFont := true -}}
 {{- with .Site.Params.fonts -}}
-  {{- if isset . "googlefonts" -}}{{- $useGoogleFonts = .googleFonts -}}{{- end -}}
-  {{- if isset . "japanesebodyfont" -}}{{- $useJPFont = .japaneseBodyFont -}}{{- end -}}
+  {{- $useGoogleFonts = cond (isset . "googlefonts") .googleFonts $useGoogleFonts -}}
+  {{- $useJPFont = cond (isset . "japanesebodyfont") .japaneseBodyFont $useJPFont -}}
 {{- end -}}
 {{- if $useGoogleFonts -}}
   {{- /* Opt-in: the theme's original Google Fonts set, loaded asynchronously.
@@ -98,11 +98,11 @@
          body    = "'Inter', 'Noto Sans JP', sans-serif"
          mono    = "'Fira Code', monospace" */ -}}
 {{- with .Site.Params.fonts -}}
+  {{- $fonts := . -}}
   {{- $overrides := slice -}}
-  {{- with .display -}}{{- $overrides = $overrides | append (printf "--font-display:%s;" .) -}}{{- end -}}
-  {{- with .ui -}}{{- $overrides = $overrides | append (printf "--font-ui:%s;" .) -}}{{- end -}}
-  {{- with .body -}}{{- $overrides = $overrides | append (printf "--font-body:%s;" .) -}}{{- end -}}
-  {{- with .mono -}}{{- $overrides = $overrides | append (printf "--font-mono:%s;" .) -}}{{- end -}}
+  {{- range $key := slice "display" "ui" "body" "mono" -}}
+    {{- with index $fonts $key -}}{{- $overrides = $overrides | append (printf "--font-%s:%s;" $key .) -}}{{- end -}}
+  {{- end -}}
   {{- with $overrides -}}
     <style>{{ printf ":root{%s}" (delimit . "") | safeCSS }}</style>
   {{- end -}}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -16,37 +16,14 @@
 <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
 <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
 
-{{- /* Fonts.
-       The theme ships NO webfonts by default — the CSS variables fall back to
-       system fonts, which is the fastest, most private option and keeps tools
-       like PageSpeed from flagging a big unused-CSS Google Fonts stylesheet.
-       Bring your own fonts entirely from the site side:
-         1. Inject the <link>/<style>/preload for your fonts via
-            layouts/partials/head/custom.html (rendered near the end of <head>).
+{{- /* Fonts — the theme loads NO webfonts. The CSS variables fall back to
+       system fonts (fastest, most private, and no unused-CSS Google Fonts
+       stylesheet for tools like PageSpeed to flag). Bring your own fonts from
+       the site side:
+         1. Load the font files in layouts/partials/head/custom.html
+            (rendered near the end of <head>).
          2. Point the CSS variables at them with [params.fonts] —
-            display / ui / body / mono (see the block after the stylesheet).
-       Or, to restore the theme's original bundled typography with no other
-       setup, flip [params.fonts] googleFonts = true. */ -}}
-{{- $useGoogleFonts := false -}}
-{{- $useJPFont := true -}}
-{{- with .Site.Params.fonts -}}
-  {{- $useGoogleFonts = cond (isset . "googlefonts") .googleFonts $useGoogleFonts -}}
-  {{- $useJPFont = cond (isset . "japanesebodyfont") .japaneseBodyFont $useJPFont -}}
-{{- end -}}
-{{- if $useGoogleFonts -}}
-  {{- /* Opt-in: the theme's original Google Fonts set, loaded asynchronously.
-         japaneseBodyFont (default true) drops the heavy Noto Sans JP CJK font
-         for non-Japanese sites. */ -}}
-  {{- $families := slice "family=Italiana" "family=DM+Sans:wght@400;500" "family=JetBrains+Mono:wght@400;600" -}}
-  {{- if $useJPFont -}}
-    {{- $families = $families | append "family=Noto+Sans+JP:wght@400;500;700" -}}
-  {{- end -}}
-  {{- $fontHref := printf "https://fonts.googleapis.com/css2?%s&display=swap" (delimit $families "&") -}}
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="{{ $fontHref }}" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="{{ $fontHref }}"></noscript>
-{{- end -}}
+            display / ui / body / mono (see the block after the stylesheet). */ -}}
 
 {{- /* OpenGraph + Twitter */ -}}
 {{ partial "head/opengraph.html" . }}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -16,12 +16,31 @@
 <link rel="manifest" href="{{ "site.webmanifest" | relURL }}">
 <link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
 
-{{- /* Fonts — load asynchronously to avoid blocking first paint */ -}}
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-{{- $fontHref := "https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap" -}}
-<link rel="stylesheet" href="{{ $fontHref }}" media="print" onload="this.media='all'">
-<noscript><link rel="stylesheet" href="{{ $fontHref }}"></noscript>
+{{- /* Fonts — load asynchronously to avoid blocking first paint.
+       Configurable via [params.fonts]:
+         googleFonts      (default true)  master toggle. false → skip the
+                          request entirely and use the system-font fallbacks
+                          baked into the CSS variables (best PageSpeed / privacy).
+         japaneseBodyFont (default true)  include the heavy Noto Sans JP CJK
+                          webfont. Non-Japanese sites can set false to drop the
+                          bulk of the Google Fonts CSS payload. */ -}}
+{{- $useGoogleFonts := true -}}
+{{- $useJPFont := true -}}
+{{- with .Site.Params.fonts -}}
+  {{- if isset . "googlefonts" -}}{{- $useGoogleFonts = .googleFonts -}}{{- end -}}
+  {{- if isset . "japanesebodyfont" -}}{{- $useJPFont = .japaneseBodyFont -}}{{- end -}}
+{{- end -}}
+{{- if $useGoogleFonts -}}
+  {{- $families := slice "family=Italiana" "family=DM+Sans:wght@400;500" "family=JetBrains+Mono:wght@400;600" -}}
+  {{- if $useJPFont -}}
+    {{- $families = $families | append "family=Noto+Sans+JP:wght@400;500;700" -}}
+  {{- end -}}
+  {{- $fontHref := printf "https://fonts.googleapis.com/css2?%s&display=swap" (delimit $families "&") -}}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="{{ $fontHref }}" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="{{ $fontHref }}"></noscript>
+{{- end -}}
 
 {{- /* OpenGraph + Twitter */ -}}
 {{ partial "head/opengraph.html" . }}

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -45,22 +45,53 @@ src = "image/avatar.webp"
 
 When `enabled = true`, the avatar appears at the top of the sidebar. With `local = true`, `src` is resolved through Hugo's asset pipeline (place the file under your site's `assets/` directory). With `local = false`, `src` is treated as an external URL.
 
-### `[params.fonts]`
+### Fonts
 
-Controls the webfonts the theme requests from Google Fonts. Both keys default to `true`, so leaving this block out keeps the full typography.
+**The theme loads no webfonts by default.** Everything falls back to the system-font stacks in the CSS variables (`--font-display`, `--font-ui`, `--font-body`, `--font-mono`), which is the fastest and most private option — and it stops tools like PageSpeed Insights from flagging a large "unused CSS" Google Fonts stylesheet (the CJK stylesheet in particular enumerates hundreds of subset `@font-face` rules).
+
+You choose the fonts from your own site, in two steps.
+
+**1. Load the font files** — create `layouts/partials/head/custom.html` in your site. It is rendered near the end of `<head>`, so put any `<link>`, `<style>`, or preload there:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap">
+```
+
+(This hook is general-purpose — you can also use it for preloads, verification `<meta>` tags, etc.)
+
+**2. Point the variables at them** — with `[params.fonts]`. Each key overrides one CSS variable, no CSS editing required:
 
 ```toml
 [params.fonts]
-googleFonts = true      # master toggle
-japaneseBodyFont = true # include Noto Sans JP (the heavy CJK webfont)
+display = "'Playfair Display', serif"        # headings / brand
+ui      = "'Inter', system-ui, sans-serif"
+body    = "'Inter', 'Noto Sans JP', sans-serif"
+mono    = "'Fira Code', monospace"
 ```
 
 | Key | Type | Description |
 |---|---|---|
-| `googleFonts` | `bool` | Load the theme's webfonts from Google Fonts. Set `false` to skip the request entirely and fall back to the system-font stacks baked into the CSS variables — the fastest and most private option. Default: `true`. |
-| `japaneseBodyFont` | `bool` | Include **Noto Sans JP** in the request. This is by far the largest part of the Google Fonts payload (its stylesheet lists hundreds of CJK subset `@font-face` rules). Non-Japanese sites can set `false` to drop it; the body text then falls back to the system Japanese fonts already listed in `--font-body`. Ignored when `googleFonts = false`. Default: `true`. |
+| `display` | `string` | Overrides `--font-display` (headings, brand, card titles). |
+| `ui` | `string` | Overrides `--font-ui` (buttons, tags, labels). |
+| `body` | `string` | Overrides `--font-body` (body copy). |
+| `mono` | `string` | Overrides `--font-mono` (code). |
 
-Tools like PageSpeed Insights flag the Google Fonts stylesheet as "unused CSS" because the CJK stylesheet enumerates every subset. If you don't need the display/mono webfonts, `googleFonts = false` removes that request; if you only want to drop the Japanese font, use `japaneseBodyFont = false`.
+#### Restoring the original bundled typography
+
+If you just want the theme's designed look (Italiana, DM Sans, Noto Sans JP, JetBrains Mono) without any of the above, flip on the bundled Google Fonts request:
+
+```toml
+[params.fonts]
+googleFonts = true       # opt back into the theme's original webfonts
+japaneseBodyFont = true  # include Noto Sans JP; false drops the heavy CJK font
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `googleFonts` | `bool` | Load the theme's original webfont set from Google Fonts (async, non-blocking). Default: `false`. |
+| `japaneseBodyFont` | `bool` | When `googleFonts = true`, include **Noto Sans JP** — by far the largest part of that payload. Non-Japanese sites can set `false` to drop it; the body text falls back to the system Japanese fonts in `--font-body`. Default: `true`. |
 
 ## Widgets
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -45,6 +45,23 @@ src = "image/avatar.webp"
 
 When `enabled = true`, the avatar appears at the top of the sidebar. With `local = true`, `src` is resolved through Hugo's asset pipeline (place the file under your site's `assets/` directory). With `local = false`, `src` is treated as an external URL.
 
+### `[params.fonts]`
+
+Controls the webfonts the theme requests from Google Fonts. Both keys default to `true`, so leaving this block out keeps the full typography.
+
+```toml
+[params.fonts]
+googleFonts = true      # master toggle
+japaneseBodyFont = true # include Noto Sans JP (the heavy CJK webfont)
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `googleFonts` | `bool` | Load the theme's webfonts from Google Fonts. Set `false` to skip the request entirely and fall back to the system-font stacks baked into the CSS variables — the fastest and most private option. Default: `true`. |
+| `japaneseBodyFont` | `bool` | Include **Noto Sans JP** in the request. This is by far the largest part of the Google Fonts payload (its stylesheet lists hundreds of CJK subset `@font-face` rules). Non-Japanese sites can set `false` to drop it; the body text then falls back to the system Japanese fonts already listed in `--font-body`. Ignored when `googleFonts = false`. Default: `true`. |
+
+Tools like PageSpeed Insights flag the Google Fonts stylesheet as "unused CSS" because the CJK stylesheet enumerates every subset. If you don't need the display/mono webfonts, `googleFonts = false` removes that request; if you only want to drop the Japanese font, use `japaneseBodyFont = false`.
+
 ## Widgets
 
 See [Widgets](/widgets/) for the per-widget configuration. There are two widget slots:

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -78,20 +78,20 @@ mono    = "'Fira Code', monospace"
 | `body` | `string` | Overrides `--font-body` (body copy). |
 | `mono` | `string` | Overrides `--font-mono` (code). |
 
-#### Restoring the original bundled typography
+#### The theme's original typography
 
-If you just want the theme's designed look (Italiana, DM Sans, Noto Sans JP, JetBrains Mono) without any of the above, flip on the bundled Google Fonts request:
+The CSS variables already name the theme's designed families first (Italiana, DM Sans, Noto Sans JP, JetBrains Mono), so to get the original look you only need to **load** those fonts — no variable overrides required. Drop this into `layouts/partials/head/custom.html`:
 
-```toml
-[params.fonts]
-googleFonts = true       # opt back into the theme's original webfonts
-japaneseBodyFont = true  # include Noto Sans JP; false drops the heavy CJK font
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" media="print" onload="this.media='all'"
+  href="https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap">
+<noscript><link rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap"></noscript>
 ```
 
-| Key | Type | Description |
-|---|---|---|
-| `googleFonts` | `bool` | Load the theme's original webfont set from Google Fonts (async, non-blocking). Default: `false`. |
-| `japaneseBodyFont` | `bool` | When `googleFonts = true`, include **Noto Sans JP** — by far the largest part of that payload. Non-Japanese sites can set `false` to drop it; the body text falls back to the system Japanese fonts in `--font-body`. Default: `true`. |
+The `media="print"` → `onload` swap loads it asynchronously so it never blocks first paint. Non-Japanese sites can drop `&family=Noto+Sans+JP:…` to skip the heavy CJK font (body text then falls back to the system Japanese fonts in `--font-body`). This is exactly what the [exampleSite](https://github.com/rin2yh/hugo-theme-stack-liquid-glass/blob/main/exampleSite/layouts/partials/head/custom.html) does.
 
 ## Widgets
 

--- a/website/src/content/docs/ja/configuration.md
+++ b/website/src/content/docs/ja/configuration.md
@@ -45,6 +45,23 @@ src = "image/avatar.webp"
 
 `enabled = true` でサイドバー先頭にアバターが表示されます。`local = true` の場合、`src` は Hugo のアセットパイプラインで解決されます（サイトの `assets/` 配下にファイルを置きます）。`local = false` の場合は外部 URL として扱われます。
 
+### `[params.fonts]`
+
+テーマが Google Fonts から読み込むウェブフォントを制御します。どちらのキーもデフォルトは `true` なので、このブロックを省略すると従来どおりすべてのフォントを読み込みます。
+
+```toml
+[params.fonts]
+googleFonts = true      # 全体のオン/オフ
+japaneseBodyFont = true # Noto Sans JP（重い CJK ウェブフォント）を含める
+```
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `googleFonts` | `bool` | テーマのウェブフォントを Google Fonts から読み込むか。`false` にするとリクエスト自体を行わず、CSS 変数に定義済みのシステムフォントにフォールバックします（最速・最もプライバシーに配慮した選択肢）。デフォルト `true`。 |
+| `japaneseBodyFont` | `bool` | リクエストに **Noto Sans JP** を含めるか。これは Google Fonts のペイロードの大部分を占めます（CJK は数百のサブセット `@font-face` 宣言に分割されるため）。日本語を使わないサイトは `false` にして除外でき、本文は `--font-body` に列挙済みのシステム日本語フォントにフォールバックします。`googleFonts = false` のときは無視されます。デフォルト `true`。 |
+
+PageSpeed Insights などは、CJK のスタイルシートが全サブセットを列挙するため、Google Fonts のスタイルシートを「未使用の CSS」として指摘します。display/mono フォントが不要なら `googleFonts = false` でリクエストを削除でき、日本語フォントだけ外したい場合は `japaneseBodyFont = false` を使います。
+
 ## ウィジェット
 
 各ウィジェットの設定は [ウィジェット](/ja/widgets/) を参照してください。ウィジェットスロットは 2 種類あります:

--- a/website/src/content/docs/ja/configuration.md
+++ b/website/src/content/docs/ja/configuration.md
@@ -45,22 +45,53 @@ src = "image/avatar.webp"
 
 `enabled = true` でサイドバー先頭にアバターが表示されます。`local = true` の場合、`src` は Hugo のアセットパイプラインで解決されます（サイトの `assets/` 配下にファイルを置きます）。`local = false` の場合は外部 URL として扱われます。
 
-### `[params.fonts]`
+### フォント
 
-テーマが Google Fonts から読み込むウェブフォントを制御します。どちらのキーもデフォルトは `true` なので、このブロックを省略すると従来どおりすべてのフォントを読み込みます。
+**テーマはデフォルトでウェブフォントを一切読み込みません。** すべて CSS 変数（`--font-display` / `--font-ui` / `--font-body` / `--font-mono`）のシステムフォントにフォールバックします。これは最速・最もプライバシーに配慮した選択肢で、PageSpeed Insights などが Google Fonts のスタイルシートを大きな「未使用の CSS」として指摘する問題も回避できます（特に CJK のスタイルシートは数百のサブセット `@font-face` 宣言を列挙します）。
+
+フォントはサイト側で、次の 2 ステップで自由に指定します。
+
+**1. フォントファイルを読み込む** — サイトに `layouts/partials/head/custom.html` を作成します。`<head>` の末尾付近で描画されるので、任意の `<link>` / `<style>` / preload をここに置きます:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap">
+```
+
+（このフックは汎用で、preload や認証用 `<meta>` タグなどにも使えます。）
+
+**2. 変数を指し向ける** — `[params.fonts]` で各キーが 1 つの CSS 変数を上書きします。CSS の編集は不要です:
 
 ```toml
 [params.fonts]
-googleFonts = true      # 全体のオン/オフ
-japaneseBodyFont = true # Noto Sans JP（重い CJK ウェブフォント）を含める
+display = "'Playfair Display', serif"        # 見出し / ブランド
+ui      = "'Inter', system-ui, sans-serif"
+body    = "'Inter', 'Noto Sans JP', sans-serif"
+mono    = "'Fira Code', monospace"
 ```
 
 | キー | 型 | 説明 |
 |---|---|---|
-| `googleFonts` | `bool` | テーマのウェブフォントを Google Fonts から読み込むか。`false` にするとリクエスト自体を行わず、CSS 変数に定義済みのシステムフォントにフォールバックします（最速・最もプライバシーに配慮した選択肢）。デフォルト `true`。 |
-| `japaneseBodyFont` | `bool` | リクエストに **Noto Sans JP** を含めるか。これは Google Fonts のペイロードの大部分を占めます（CJK は数百のサブセット `@font-face` 宣言に分割されるため）。日本語を使わないサイトは `false` にして除外でき、本文は `--font-body` に列挙済みのシステム日本語フォントにフォールバックします。`googleFonts = false` のときは無視されます。デフォルト `true`。 |
+| `display` | `string` | `--font-display`（見出し・ブランド・カードタイトル）を上書き。 |
+| `ui` | `string` | `--font-ui`（ボタン・タグ・ラベル）を上書き。 |
+| `body` | `string` | `--font-body`（本文）を上書き。 |
+| `mono` | `string` | `--font-mono`（コード）を上書き。 |
 
-PageSpeed Insights などは、CJK のスタイルシートが全サブセットを列挙するため、Google Fonts のスタイルシートを「未使用の CSS」として指摘します。display/mono フォントが不要なら `googleFonts = false` でリクエストを削除でき、日本語フォントだけ外したい場合は `japaneseBodyFont = false` を使います。
+#### 元のバンドルフォントに戻す
+
+上記を行わずにテーマ本来の見た目（Italiana・DM Sans・Noto Sans JP・JetBrains Mono）が欲しい場合は、バンドル済みの Google Fonts リクエストを有効にします:
+
+```toml
+[params.fonts]
+googleFonts = true       # テーマ本来のウェブフォントを有効化
+japaneseBodyFont = true  # Noto Sans JP を含める。false で重い CJK フォントを除外
+```
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `googleFonts` | `bool` | テーマ本来のウェブフォント一式を Google Fonts から読み込む（非同期・非ブロッキング）。デフォルト `false`。 |
+| `japaneseBodyFont` | `bool` | `googleFonts = true` のとき、**Noto Sans JP** を含めるか。これはペイロードの大部分を占めます。日本語を使わないサイトは `false` で除外でき、本文は `--font-body` のシステム日本語フォントにフォールバックします。デフォルト `true`。 |
 
 ## ウィジェット
 

--- a/website/src/content/docs/ja/configuration.md
+++ b/website/src/content/docs/ja/configuration.md
@@ -78,20 +78,20 @@ mono    = "'Fira Code', monospace"
 | `body` | `string` | `--font-body`（本文）を上書き。 |
 | `mono` | `string` | `--font-mono`（コード）を上書き。 |
 
-#### 元のバンドルフォントに戻す
+#### テーマ本来のタイポグラフィ
 
-上記を行わずにテーマ本来の見た目（Italiana・DM Sans・Noto Sans JP・JetBrains Mono）が欲しい場合は、バンドル済みの Google Fonts リクエストを有効にします:
+CSS 変数はテーマ本来のファミリー（Italiana・DM Sans・Noto Sans JP・JetBrains Mono）を先頭に指定済みなので、本来の見た目にするにはそれらを**読み込む**だけでよく、変数の上書きは不要です。次を `layouts/partials/head/custom.html` に置きます:
 
-```toml
-[params.fonts]
-googleFonts = true       # テーマ本来のウェブフォントを有効化
-japaneseBodyFont = true  # Noto Sans JP を含める。false で重い CJK フォントを除外
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" media="print" onload="this.media='all'"
+  href="https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap">
+<noscript><link rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Italiana&family=DM+Sans:wght@400;500&family=Noto+Sans+JP:wght@400;500;700&family=JetBrains+Mono:wght@400;600&display=swap"></noscript>
 ```
 
-| キー | 型 | 説明 |
-|---|---|---|
-| `googleFonts` | `bool` | テーマ本来のウェブフォント一式を Google Fonts から読み込む（非同期・非ブロッキング）。デフォルト `false`。 |
-| `japaneseBodyFont` | `bool` | `googleFonts = true` のとき、**Noto Sans JP** を含めるか。これはペイロードの大部分を占めます。日本語を使わないサイトは `false` で除外でき、本文は `--font-body` のシステム日本語フォントにフォールバックします。デフォルト `true`。 |
+`media="print"` → `onload` の切り替えで非同期に読み込むため、初回描画をブロックしません。日本語を使わないサイトは `&family=Noto+Sans+JP:…` を外せば重い CJK フォントを省けます（本文は `--font-body` のシステム日本語フォントにフォールバック）。これは [exampleSite](https://github.com/rin2yh/hugo-theme-stack-liquid-glass/blob/main/exampleSite/layouts/partials/head/custom.html) が実際に行っている内容そのものです。
 
 ## ウィジェット
 


### PR DESCRIPTION
## Background

A PageSpeed Insights report on a site using this theme flagged the Google Fonts stylesheet as **~90 KiB of "unused CSS"** (the Noto Sans JP CJK stylesheet enumerates hundreds of subset `@font-face` rules). The theme was hardcoding four Google Fonts families into every page.

The report's other two findings (unused JavaScript + forced reflow) both come from **Google Tag Manager / gtag.js** — the site owner's analytics config, not something the theme controls. This PR addresses the theme-attributable finding by **handing font choice entirely to the site**.

## What changed

**The theme loads no webfonts.** Everything falls back to the system-font stacks in the CSS variables (`--font-display`, `--font-ui`, `--font-body`, `--font-mono`) — fastest, most private, and no Google Fonts stylesheet for PageSpeed to flag. Sites bring their own fonts through two small, composable primitives:

1. **`layouts/partials/head/custom.html`** — a site-provided hook rendered near the end of `<head>`. Put any font `<link>`/`<style>`/preload there (also usable for preloads, verification meta, etc.).
2. **`[params.fonts]` `display` / `ui` / `body` / `mono`** — override the `--font-*` CSS variables without editing CSS. Emitted as an inline `:root` style after the stylesheet so it wins by source order.

That's the whole surface. The `exampleSite` demonstrates it directly: its own `layouts/partials/head/custom.html` loads the theme's original typography (Italiana, DM Sans, Noto Sans JP, JetBrains Mono) — the CSS variables already name those families first, so no overrides are needed. To restore the designed look on your own site, copy that same snippet (documented in the Fonts config reference).

## ⚠️ Breaking change

The theme no longer loads Google Fonts. Sites that want the bundled look should load the fonts in `layouts/partials/head/custom.html` (copy-paste snippet in the docs). An earlier revision of this PR added a `[params.fonts] googleFonts = true` flag; that was removed in favour of the generic hook so the theme core owns exactly one loading mechanism and one variable-mapping mechanism.

## Docs

- Rewrote the Fonts section of the config reference (`configuration.md` + `ja/configuration.md`) around the two site-side mechanisms, with a copy-paste `custom.html` snippet for the original typography.
- Updated `exampleSite/hugo.toml` and added `exampleSite/layouts/partials/head/custom.html`.

## Verification

Built `exampleSite` and a bare site with Hugo 0.146.0 (extended, production) and confirmed in the generated HTML:

- **bare site (no `custom.html`, no `[params.fonts]`)** → zero `fonts.googleapis.com` references; `/css/liquid-glass.css` still linked.
- **`[params.fonts]` display/body/mono** → `<style>:root{--font-display:…;--font-body:…}</style>` emitted after the stylesheet.
- **exampleSite (`custom.html` present)** → the font `<link>`s appear in `<head>` and Italiana renders (verified with Playwright/Chromium — the glass design is fully intact, only the display font differs from system serif).

A `/simplify` pass over the diff applied two cleanups (use the repo's own `cond (isset …)` idiom for the param toggles; `range` the four variable overrides instead of copy-paste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)