### PR TITLE
perf(ogp): eager-load the first card image and downsize twimg sources

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -14,13 +14,13 @@
 {{- $external := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") -}}
 {{- $isBareURL := and $external (eq (trim $plain " ") (trim $dest " ")) -}}
 {{- if $isBareURL -}}
-  {{- /* Number the OGP cards in document order. Hugo renders (and memoizes) a
-         page's content once, so the first card — ordinal 0 — is reliably the
-         one nearest the top and the likely LCP element. It is fetched eagerly
-         with a high priority; every later card stays lazy. */ -}}
-  {{- $ordinal := .Page.Store.Get "ogpCardOrdinal" | default 0 -}}
-  {{- .Page.Store.Set "ogpCardOrdinal" (add $ordinal 1) -}}
-  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (eq $ordinal 0)) -}}
+  {{- /* Mark only the first OGP card on the page as eager. Hugo renders (and
+         memoizes) a page's content once, so the first card is reliably the one
+         nearest the top and the likely LCP element: it is fetched eagerly with
+         a high priority, while every later card stays lazy. */ -}}
+  {{- $seen := .Page.Store.Get "ogpCardSeen" -}}
+  {{- .Page.Store.Set "ogpCardSeen" true -}}
+  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen)) -}}
 {{- else -}}
   <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -14,7 +14,13 @@
 {{- $external := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") -}}
 {{- $isBareURL := and $external (eq (trim $plain " ") (trim $dest " ")) -}}
 {{- if $isBareURL -}}
-  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text) -}}
+  {{- /* Number the OGP cards in document order. Hugo renders (and memoizes) a
+         page's content once, so the first card — ordinal 0 — is reliably the
+         one nearest the top and the likely LCP element. It is fetched eagerly
+         with a high priority; every later card stays lazy. */ -}}
+  {{- $ordinal := .Page.Store.Get "ogpCardOrdinal" | default 0 -}}
+  {{- .Page.Store.Set "ogpCardOrdinal" (add $ordinal 1) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (eq $ordinal 0)) -}}
 {{- else -}}
   <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}

--- a/layouts/partials/helper/ogp-card.html
+++ b/layouts/partials/helper/ogp-card.html
@@ -26,19 +26,8 @@
 {{- if $ogp.ok -}}
 <a class="ogp-card" href="{{ $url }}" target="_blank" rel="noopener noreferrer">
   {{- with $ogp.image }}
-    {{- /* The card displays the image only a few hundred px wide, so request a
-           smaller variant when the source is a known CDN that serves oversized
-           files. Twitter/X media exposes :thumb/:small/:medium/:large/:orig
-           suffixes (and the equivalent name=… query); :large is 2048px wide,
-           :medium 1200px — ample for this card and a large byte saving on what
-           is often the LCP image. */ -}}
-    {{- $src := . -}}
-    {{- if in $src "pbs.twimg.com" -}}
-      {{- $src = $src | replaceRE ":(large|orig)$" ":medium" -}}
-      {{- $src = $src | replaceRE "([?&]name=)(large|orig)(&|$)" "${1}medium${3}" -}}
-    {{- end }}
   <span class="ogp-card__image">
-    <img src="{{ $src }}" decoding="async"{{ if $eager }} fetchpriority="high"{{ else }} loading="lazy"{{ end }} alt="">
+    <img src="{{ . }}" decoding="async"{{ if $eager }} fetchpriority="high"{{ else }} loading="lazy"{{ end }} alt="">
   </span>
   {{- end }}
   <span class="ogp-card__body">

--- a/layouts/partials/helper/ogp-card.html
+++ b/layouts/partials/helper/ogp-card.html
@@ -11,6 +11,10 @@
 {{- $text := or .text $url -}}
 {{- $external := or (hasPrefix $url "http://") (hasPrefix $url "https://") -}}
 
+{{- /* The first card on a page is loaded eagerly with a high fetch priority
+       (it is the likely LCP element); every other card stays lazy. */ -}}
+{{- $eager := .eager -}}
+
 {{- /* On by default; opt out with params.ogpCard.enabled = false. */ -}}
 {{- $enabled := ne site.Params.ogpCard.enabled false -}}
 
@@ -22,8 +26,19 @@
 {{- if $ogp.ok -}}
 <a class="ogp-card" href="{{ $url }}" target="_blank" rel="noopener noreferrer">
   {{- with $ogp.image }}
+    {{- /* The card displays the image only a few hundred px wide, so request a
+           smaller variant when the source is a known CDN that serves oversized
+           files. Twitter/X media exposes :thumb/:small/:medium/:large/:orig
+           suffixes (and the equivalent name=… query); :large is 2048px wide,
+           :medium 1200px — ample for this card and a large byte saving on what
+           is often the LCP image. */ -}}
+    {{- $src := . -}}
+    {{- if in $src "pbs.twimg.com" -}}
+      {{- $src = $src | replaceRE ":(large|orig)$" ":medium" -}}
+      {{- $src = $src | replaceRE "([?&]name=)(large|orig)(&|$)" "${1}medium${3}" -}}
+    {{- end }}
   <span class="ogp-card__image">
-    <img src="{{ . }}" loading="lazy" decoding="async" alt="">
+    <img src="{{ $src }}" decoding="async"{{ if $eager }} fetchpriority="high"{{ else }} loading="lazy"{{ end }} alt="">
   </span>
   {{- end }}
   <span class="ogp-card__body">

--- a/layouts/partials/helper/ogp.html
+++ b/layouts/partials/helper/ogp.html
@@ -57,6 +57,16 @@
           {{- end -}}
         {{- end -}}
 
+        {{- /* Downsize oversized CDN images to a variant that suits the card
+               (displayed only a few hundred px wide). Twitter/X media exposes
+               :thumb/:small/:medium/:large/:orig suffixes (and the equivalent
+               name=… query); :large is 2048px, :medium 1200px — a large byte
+               saving on what is often the LCP image. Other origins pass through. */ -}}
+        {{- if and $image (in $image "pbs.twimg.com") -}}
+          {{- $image = $image | replaceRE ":(large|orig)$" ":medium" -}}
+          {{- $image = $image | replaceRE "([?&]name=)(large|orig)(&|$)" "${1}medium${3}" -}}
+        {{- end -}}
+
         {{- if not $siteName -}}{{- $siteName = $base.Host -}}{{- end -}}
 
         {{- if $title -}}


### PR DESCRIPTION
## 背景

`srenext-day2` 記事のモバイル PageSpeed（Lighthouse 13.4.0 / Moto G Power エミュ）で、パフォーマンス 82 の唯一のボトルネックが **LCP 4.9s**。他指標（FCP 1.2s / TBT 50ms / CLS 0 / SI 2.7s）は良好。

LCP 要素は記事冒頭の **OGP カードの画像**（`pbs.twimg.com/media/…:large`）で、PSI が次を名指しで指摘していた：

- 「LCP 画像に `loading="lazy"` が付いている → `fetchpriority="high"` を付け lazy を外すべき」
- 「画像配信 470 KiB 削減余地」— 表示は数百 px 幅なのに 2048px を配信

このカードの描画はテーマ（`ogp-card.html` / `render-link.html`）が担っているため、テーマ側で対応する。

## 変更内容

- **先頭 OGP カードを eager 化**：`render-link.html` で `.Page.Store` を使いカードをドキュメント順に採番。Hugo はページ本文を一度だけ描画してメモ化するため、先頭（ordinal 0）が確実に最上部＝ LCP 候補になる。先頭のみ `fetchpriority="high"`（lazy なし）、2 枚目以降は従来どおり `loading="lazy"`。
- **twimg 画像の縮小**：`pbs.twimg.com` の `:large`/`:orig`（および `name=` クエリ形式）を `:medium`（1200px）へ書き換え。カードの表示幅からすると 1200px で十分で、LCP 画像のダウンロード量を大きく削減。`pbs.twimg.com` 以外のオリジン、および `profile_images`（`:large` を持たない）は不変で安全。

## 検証

Hugo v0.164.0 でローカルビルドし、OGP 取得をスタブして実記事の出力を確認：

- 先頭カード：``'&lt;img src=…:medium decoding=async fetchpriority=high alt&gt;'`` ✅
- 2〜10 枚目：``'&lt;img src=…:medium decoding=async loading=lazy alt&gt;'`` ✅
- URL 書き換えは `:large`/`:orig`/`?name=large`/`?name=orig` を medium 化、`profile_images` と speakerdeck は不変であることを個別に確認 ✅

CLS への影響なし（画像は `object-fit: cover` + flex で寸法確定済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaaFhTfYyJwRgvrC5Apkqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaaFhTfYyJwRgvrC5Apkqp)_