### PR TITLE
perf(ogp): preconnect to the eager card image origin on mobile

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -20,7 +20,7 @@
          a high priority, while every later card stays lazy. */ -}}
   {{- $seen := .Page.Store.Get "ogpCardSeen" -}}
   {{- .Page.Store.Set "ogpCardSeen" true -}}
-  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen)) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen) "page" .Page) -}}
 {{- else -}}
   <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -28,6 +28,18 @@
 {{- /* OpenGraph + Twitter */ -}}
 {{ partial "head/opengraph.html" . }}
 
+{{- /* Preconnect to the eager OGP card's image origin.
+       The card's image URL is only known after the content render hooks run,
+       so evaluate .Content here to populate .Store. Hugo memoizes .Content, so
+       the body reuses this render at no extra cost. Emitting the hint inside
+       <head>, before the render-blocking stylesheet, lets the browser open the
+       connection while CSS downloads — moving the DNS/TCP/TLS handshake off
+       the LCP critical path. Nothing is emitted when there is no eager card. */ -}}
+{{- $_ := .Content -}}
+{{- with .Store.Get "ogpPreconnect" -}}
+<link rel="preconnect" href="{{ . }}">
+{{- end -}}
+
 {{- /* Stylesheet pipeline — plain CSS concat */ -}}
 {{- $cssFiles := slice
   "css/partials/_tokens.css"

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -30,12 +30,15 @@
 
 {{- /* Preconnect to the eager OGP card's image origin.
        The card's image URL is only known after the content render hooks run,
-       so evaluate .Content here to populate .Store. Hugo memoizes .Content, so
-       the body reuses this render at no extra cost. Emitting the hint inside
-       <head>, before the render-blocking stylesheet, lets the browser open the
-       connection while CSS downloads — moving the DNS/TCP/TLS handshake off
-       the LCP critical path. Nothing is emitted when there is no eager card. */ -}}
-{{- $_ := .Content -}}
+       so evaluate .Content here to populate .Store. Only single pages render
+       .Content in their body, so gating on .IsPage keeps this free — the body
+       reuses Hugo's memoized render — and avoids forcing an otherwise-skipped
+       render (and its build-time OGP fetches) on list/home/taxonomy pages,
+       which never show a card. Emitting the hint inside <head>, before the
+       render-blocking stylesheet, lets the browser open the connection while
+       CSS downloads — moving the DNS/TCP/TLS handshake off the LCP critical
+       path. Nothing is emitted when there is no eager card. */ -}}
+{{- if .IsPage -}}{{- $_ := .Content -}}{{- end -}}
 {{- with .Store.Get "ogpPreconnect" -}}
 <link rel="preconnect" href="{{ . }}">
 {{- end -}}

--- a/layouts/partials/helper/ogp-card.html
+++ b/layouts/partials/helper/ogp-card.html
@@ -4,8 +4,10 @@
   Falls back to a plain anchor when OGP fetching is disabled or the target
   exposes no usable metadata, so content always renders something clickable.
 
-  Input: dict { url, text }
+  Input: dict { url, text, eager, page }
          text = anchor label used for the fallback link (defaults to url)
+         page = the owning Page, used to record a preconnect hint for the
+                eager card's image origin (optional)
 */ -}}
 {{- $url := .url -}}
 {{- $text := or .text $url -}}
@@ -14,6 +16,7 @@
 {{- /* The first card on a page is loaded eagerly with a high fetch priority
        (it is the likely LCP element); every other card stays lazy. */ -}}
 {{- $eager := .eager -}}
+{{- $page := .page -}}
 
 {{- /* On by default; opt out with params.ogpCard.enabled = false. */ -}}
 {{- $enabled := ne site.Params.ogpCard.enabled false -}}
@@ -24,6 +27,17 @@
 {{- end -}}
 
 {{- if $ogp.ok -}}
+  {{- /* Record the eager card's image origin so <head> can emit a
+         <link rel="preconnect"> before the render-blocking stylesheet, pulling
+         the DNS/TCP/TLS handshake off the LCP critical path. Plain <img>
+         (no crossorigin attr) uses a credentialed connection, so the hint is
+         emitted without crossorigin to match. */ -}}
+  {{- if and $eager $page $ogp.image -}}
+    {{- $u := urls.Parse $ogp.image -}}
+    {{- with $u.Host -}}
+      {{- $page.Store.Set "ogpPreconnect" (printf "%s://%s" $u.Scheme .) -}}
+    {{- end -}}
+  {{- end -}}
 <a class="ogp-card" href="{{ $url }}" target="_blank" rel="noopener noreferrer">
   {{- with $ogp.image }}
   <span class="ogp-card__image">

--- a/layouts/shortcodes/ogp.html
+++ b/layouts/shortcodes/ogp.html
@@ -10,7 +10,7 @@
 */ -}}
 {{- $url := or (.Get "url") (.Get 0) -}}
 {{- with $url -}}
-  {{- partial "helper/ogp-card.html" (dict "url" (trim . " ")) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" (trim . " ") "page" $.Page) -}}
 {{- else -}}
   {{- errorf "ogp shortcode: a URL is required (%s)" .Position -}}
 {{- end -}}


### PR DESCRIPTION
## 背景

モバイルの PageSpeed で LCP 3.8s（唯一の "要改善"）。記事ページの LCP 要素は先頭の OGP リンクカードの画像で、その画像は外部オリジン（`pbs.twimg.com` / `files.speakerdeck.com` 等）にある。モバイルではこの画像の DNS/TCP/TLS ハンドシェイクが LCP クリティカルパス上に乗っていた。

## 変更

先頭（eager）カードの画像オリジンへ `<link rel="preconnect">` を `<head>` 内・render-blocking な stylesheet より前に出力し、接続確立を LCP パスから前倒しする。

- カードの画像 URL は content の render hook 実行後にしか判明しないため、`head/head.html` で `.Content` を先に評価して `.Store` を埋める。Hugo は `.Content` をメモ化するので body 側の描画は再利用され追加コストはない。
- オリジンは `ogp-card.html` で eager カードのときだけ per-page の `.Store` キー（`ogpPreconnect`）に格納。`render-link.html` / `shortcodes/ogp.html` から `.Page` を渡すよう変更。
- OGP 取得失敗時や画像なしのカードでは何も出力しない（安全なフォールバック）。

## 検証

Hugo v0.146 でモック OGP を使いローカルビルド：

- 先頭カードの分だけ `<link rel="preconnect" href="https://pbs.twimg.com">` を 1 回出力（2 枚目以降のカードは対象外）。
- 出力位置は `<head>` 内で stylesheet より前。
- eager カードの `fetchpriority="high"` / 後続カードの `loading="lazy"` は不変（twimg の `name=large`→`medium` 縮小も維持）。
- exampleSite フルビルド（58 ページ）でテンプレートエラーなし。OGP 取得失敗時はカードが素のリンクへフォールバックし preconnect は出力されないことも確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGyBag9NTRLyzGGffDktEG)_