### PR TITLE
revert(ogp): drop the per-service eager/preconnect/twimg card tweaks

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -14,13 +14,7 @@
 {{- $external := or (hasPrefix $dest "http://") (hasPrefix $dest "https://") -}}
 {{- $isBareURL := and $external (eq (trim $plain " ") (trim $dest " ")) -}}
 {{- if $isBareURL -}}
-  {{- /* Mark only the first OGP card on the page as eager. Hugo renders (and
-         memoizes) a page's content once, so the first card is reliably the one
-         nearest the top and the likely LCP element: it is fetched eagerly with
-         a high priority, while every later card stays lazy. */ -}}
-  {{- $seen := .Page.Store.Get "ogpCardSeen" -}}
-  {{- .Page.Store.Set "ogpCardSeen" true -}}
-  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen)) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text) -}}
 {{- else -}}
   <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -20,7 +20,7 @@
          a high priority, while every later card stays lazy. */ -}}
   {{- $seen := .Page.Store.Get "ogpCardSeen" -}}
   {{- .Page.Store.Set "ogpCardSeen" true -}}
-  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen) "page" .Page) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" $dest "text" .Text "eager" (not $seen)) -}}
 {{- else -}}
   <a href="{{ $dest | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
 {{- end -}}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -28,21 +28,6 @@
 {{- /* OpenGraph + Twitter */ -}}
 {{ partial "head/opengraph.html" . }}
 
-{{- /* Preconnect to the eager OGP card's image origin.
-       The card's image URL is only known after the content render hooks run,
-       so evaluate .Content here to populate .Store. Only single pages render
-       .Content in their body, so gating on .IsPage keeps this free — the body
-       reuses Hugo's memoized render — and avoids forcing an otherwise-skipped
-       render (and its build-time OGP fetches) on list/home/taxonomy pages,
-       which never show a card. Emitting the hint inside <head>, before the
-       render-blocking stylesheet, lets the browser open the connection while
-       CSS downloads — moving the DNS/TCP/TLS handshake off the LCP critical
-       path. Nothing is emitted when there is no eager card. */ -}}
-{{- if .IsPage -}}{{- $_ := .Content -}}{{- end -}}
-{{- with .Store.Get "ogpPreconnect" -}}
-<link rel="preconnect" href="{{ . }}">
-{{- end -}}
-
 {{- /* Stylesheet pipeline — plain CSS concat */ -}}
 {{- $cssFiles := slice
   "css/partials/_tokens.css"

--- a/layouts/partials/helper/ogp-card.html
+++ b/layouts/partials/helper/ogp-card.html
@@ -4,10 +4,8 @@
   Falls back to a plain anchor when OGP fetching is disabled or the target
   exposes no usable metadata, so content always renders something clickable.
 
-  Input: dict { url, text, eager, page }
+  Input: dict { url, text }
          text = anchor label used for the fallback link (defaults to url)
-         page = the owning Page, used to record a preconnect hint for the
-                eager card's image origin (optional)
 */ -}}
 {{- $url := .url -}}
 {{- $text := or .text $url -}}
@@ -16,7 +14,6 @@
 {{- /* The first card on a page is loaded eagerly with a high fetch priority
        (it is the likely LCP element); every other card stays lazy. */ -}}
 {{- $eager := .eager -}}
-{{- $page := .page -}}
 
 {{- /* On by default; opt out with params.ogpCard.enabled = false. */ -}}
 {{- $enabled := ne site.Params.ogpCard.enabled false -}}
@@ -27,17 +24,6 @@
 {{- end -}}
 
 {{- if $ogp.ok -}}
-  {{- /* Record the eager card's image origin so <head> can emit a
-         <link rel="preconnect"> before the render-blocking stylesheet, pulling
-         the DNS/TCP/TLS handshake off the LCP critical path. Plain <img>
-         (no crossorigin attr) uses a credentialed connection, so the hint is
-         emitted without crossorigin to match. */ -}}
-  {{- if and $eager $page $ogp.image -}}
-    {{- $u := urls.Parse $ogp.image -}}
-    {{- with $u.Host -}}
-      {{- $page.Store.Set "ogpPreconnect" (printf "%s://%s" $u.Scheme .) -}}
-    {{- end -}}
-  {{- end -}}
 <a class="ogp-card" href="{{ $url }}" target="_blank" rel="noopener noreferrer">
   {{- with $ogp.image }}
   <span class="ogp-card__image">

--- a/layouts/partials/helper/ogp-card.html
+++ b/layouts/partials/helper/ogp-card.html
@@ -11,10 +11,6 @@
 {{- $text := or .text $url -}}
 {{- $external := or (hasPrefix $url "http://") (hasPrefix $url "https://") -}}
 
-{{- /* The first card on a page is loaded eagerly with a high fetch priority
-       (it is the likely LCP element); every other card stays lazy. */ -}}
-{{- $eager := .eager -}}
-
 {{- /* On by default; opt out with params.ogpCard.enabled = false. */ -}}
 {{- $enabled := ne site.Params.ogpCard.enabled false -}}
 
@@ -27,7 +23,7 @@
 <a class="ogp-card" href="{{ $url }}" target="_blank" rel="noopener noreferrer">
   {{- with $ogp.image }}
   <span class="ogp-card__image">
-    <img src="{{ . }}" decoding="async"{{ if $eager }} fetchpriority="high"{{ else }} loading="lazy"{{ end }} alt="">
+    <img src="{{ . }}" loading="lazy" decoding="async" alt="">
   </span>
   {{- end }}
   <span class="ogp-card__body">

--- a/layouts/partials/helper/ogp.html
+++ b/layouts/partials/helper/ogp.html
@@ -57,16 +57,6 @@
           {{- end -}}
         {{- end -}}
 
-        {{- /* Downsize oversized CDN images to a variant that suits the card
-               (displayed only a few hundred px wide). Twitter/X media exposes
-               :thumb/:small/:medium/:large/:orig suffixes (and the equivalent
-               name=… query); :large is 2048px, :medium 1200px — a large byte
-               saving on what is often the LCP image. Other origins pass through. */ -}}
-        {{- if and $image (in $image "pbs.twimg.com") -}}
-          {{- $image = $image | replaceRE ":(large|orig)$" ":medium" -}}
-          {{- $image = $image | replaceRE "([?&]name=)(large|orig)(&|$)" "${1}medium${3}" -}}
-        {{- end -}}
-
         {{- if not $siteName -}}{{- $siteName = $base.Host -}}{{- end -}}
 
         {{- if $title -}}

--- a/layouts/shortcodes/ogp.html
+++ b/layouts/shortcodes/ogp.html
@@ -10,7 +10,7 @@
 */ -}}
 {{- $url := or (.Get "url") (.Get 0) -}}
 {{- with $url -}}
-  {{- partial "helper/ogp-card.html" (dict "url" (trim . " ") "page" $.Page) -}}
+  {{- partial "helper/ogp-card.html" (dict "url" (trim . " ")) -}}
 {{- else -}}
   {{- errorf "ogp shortcode: a URL is required (%s)" .Position -}}
 {{- end -}}


### PR DESCRIPTION
## What

Reverts the two OGP-card performance commits:

- Revert #78 `perf(ogp): preconnect to the eager card image origin on mobile`
- Revert #76 `perf(ogp): eager-load the first card image and downsize twimg sources`

This restores the OGP card templates (`render-link.html`, `helper/ogp-card.html`, `helper/ogp.html`, `head/head.html`, `shortcodes/ogp.html`) to their pre-#76 state (as shipped in v0.5.3).

`content-visibility` (#74) and the self-hosted fonts change (#72) are **kept** — they are unrelated to this revert.

## Why

A mobile PageSpeed run scored 80, with LCP (4.6s) as the sole metric losing points (TBT/CLS/FCP/SI are all near-max). The LCP element is a heavy third-party OGP card image on a deliberately harsh test (Moto G Power, emulated 4G).

The reverted commits took a per-service approach — special-casing `pbs.twimg.com` (`:medium` downsize) and eager/preconnect heuristics — whose benefit couldn't be demonstrated and which doesn't generalize: every new embedded service (speakerdeck, etc.) would need the same manual treatment. Rather than keep adding per-origin tweaks, we roll these back to a clean baseline. Any future work on card-image weight should be a single origin-agnostic mechanism (e.g. build-time resize + re-encode), decided separately.

## Verification

- `git revert` applied cleanly for both commits (no conflicts).
- `hugo --gc --minify` builds the exampleSite successfully (58 pages, no errors); the per-service markers (`twimg`, `:medium`, `fetchpriority`, `ogpPreconnect`, eager) are gone from the templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwDBaeVMmPv8APQrGYm453

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwDBaeVMmPv8APQrGYm453)_